### PR TITLE
Add support for identity providers mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Get the identity provider (`GET /{realm}/identity-provider/instances/{alias}`)
 - Update the identity provider (`PUT /{realm}/identity-provider/instances/{alias}`)
 - Delete the identity provider (`DELETE /{realm}/identity-provider/instances/{alias}`)
+- Find identity provider factory (`GET /{realm}/identity-provider//providers/{providerId}`)
+- Create a new identity provider mapper (`POST /{realm}/identity-provider/instances/{alias}/mappers`)
+- Get identity provider mappers (`GET /{realm}/identity-provider/instances/{alias}/mappers`)
+- Get the identity provider mapper (`GET /{realm}/identity-provider/instances/{alias}/mappers/{id}`)
+- Update the identity provider mapper (`PUT /{realm}/identity-provider/instances/{alias}/mappers/{id}`)
+- Delete the identity provider mapper (`DELETE /{realm}/identity-provider/instances/{alias}/mappers/{id}`)
+- Find the identity provider mapper types (`GET /{realm}/identity-provider/instances/{alias}/mapper-types`)
 
 ### [Component]()
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Get the identity provider (`GET /{realm}/identity-provider/instances/{alias}`)
 - Update the identity provider (`PUT /{realm}/identity-provider/instances/{alias}`)
 - Delete the identity provider (`DELETE /{realm}/identity-provider/instances/{alias}`)
-- Find identity provider factory (`GET /{realm}/identity-provider//providers/{providerId}`)
+- Find identity provider factory (`GET /{realm}/identity-provider/providers/{providerId}`)
 - Create a new identity provider mapper (`POST /{realm}/identity-provider/instances/{alias}/mappers`)
 - Get identity provider mappers (`GET /{realm}/identity-provider/instances/{alias}/mappers`)
 - Get the identity provider mapper (`GET /{realm}/identity-provider/instances/{alias}/mappers/{id}`)

--- a/src/defs/identityProviderMapperRepresentation.ts
+++ b/src/defs/identityProviderMapperRepresentation.ts
@@ -1,0 +1,11 @@
+/**
+ * https://www.keycloak.org/docs-api/4.1/rest-api/#_identityprovidermapperrepresentation
+ */
+
+export default interface IdentityProviderMapperRepresentation {
+  config?: any;
+  id?: string;
+  identityProviderAlias?: string;
+  identityProviderMapper?: string;
+  name?: string;
+}

--- a/src/resources/identityProviders.ts
+++ b/src/resources/identityProviders.ts
@@ -1,5 +1,6 @@
 import Resource from './resource';
 import IdentityProviderRepresentation from '../defs/identityProviderRepresentation';
+import IdentityProviderMapperRepresentation from '../defs/identityProviderMapperRepresentation';
 import {KeycloakAdminClient} from '../client';
 
 export class IdentityProviders extends Resource<{realm?: string}> {
@@ -10,10 +11,12 @@ export class IdentityProviders extends Resource<{realm?: string}> {
 
   public find = this.makeRequest<void, IdentityProviderRepresentation[]>({
     method: 'GET',
+    path: '/instances',
   });
 
   public create = this.makeRequest<IdentityProviderRepresentation, void>({
     method: 'POST',
+    path: '/instances',
   });
 
   public findOne = this.makeRequest<
@@ -21,7 +24,7 @@ export class IdentityProviders extends Resource<{realm?: string}> {
     IdentityProviderRepresentation
   >({
     method: 'GET',
-    path: '/{alias}',
+    path: '/instances/{alias}',
     urlParamKeys: ['alias'],
     catchNotFound: true,
   });
@@ -32,19 +35,78 @@ export class IdentityProviders extends Resource<{realm?: string}> {
     void
   >({
     method: 'PUT',
-    path: '/{alias}',
+    path: '/instances/{alias}',
     urlParamKeys: ['alias'],
   });
 
   public del = this.makeRequest<{alias: string}, void>({
     method: 'DELETE',
-    path: '/{alias}',
+    path: '/instances/{alias}',
+    urlParamKeys: ['alias'],
+  });
+
+
+  public findFactory = this.makeRequest<
+    {providerId: string},
+    any
+  >({
+    method: 'GET',
+    path: '/providers/{providerId}',
+    urlParamKeys: ['providerId'],
+  });
+
+
+  public findMappers = this.makeRequest<
+    {alias: string},
+    IdentityProviderMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/instances/{alias}/mappers',
+    urlParamKeys: ['alias'],
+  });
+
+  public createMapper = this.makeRequest<
+    {
+      alias: string;
+      identityProviderMapper: IdentityProviderMapperRepresentation;
+    },
+    void
+  >({
+    method: 'POST',
+    path: '/instances/{alias}/mappers',
+    urlParamKeys: ['alias'],
+    payloadKey: 'identityProviderMapper',
+  });
+
+  public updateMapper = this.makeUpdateRequest<
+    {alias: string, id: string},
+    IdentityProviderRepresentation,
+    void
+  >({
+    method: 'PUT',
+    path: '/instances/{alias}/mappers/{id}',
+    urlParamKeys: ['alias', 'id'],
+  });
+
+  public delMapper = this.makeRequest<{alias: string, id: string}, void>({
+    method: 'DELETE',
+    path: '/instances/{alias}/mappers/{id}',
+    urlParamKeys: ['alias', 'id'],
+  });
+
+
+  public findMapperTypes = this.makeRequest<
+    {alias: string},
+    IdentityProviderMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/instances/{alias}/mapper-types',
     urlParamKeys: ['alias'],
   });
 
   constructor(client: KeycloakAdminClient) {
     super(client, {
-      path: '/admin/realms/{realm}/identity-provider/instances',
+      path: '/admin/realms/{realm}/identity-provider',
       getUrlParams: () => ({
         realm: client.realmName,
       }),

--- a/src/resources/identityProviders.ts
+++ b/src/resources/identityProviders.ts
@@ -60,6 +60,16 @@ export class IdentityProviders extends Resource<{realm?: string}> {
     urlParamKeys: ['alias'],
   });
 
+  public findOneMapper = this.makeRequest<
+    {alias: string; id: string},
+    IdentityProviderMapperRepresentation
+  >({
+    method: 'GET',
+    path: '/instances/{alias}/mappers/{id}',
+    urlParamKeys: ['alias', 'id'],
+    catchNotFound: true,
+  });
+
   public createMapper = this.makeRequest<
     {
       alias: string;

--- a/src/resources/identityProviders.ts
+++ b/src/resources/identityProviders.ts
@@ -45,16 +45,11 @@ export class IdentityProviders extends Resource<{realm?: string}> {
     urlParamKeys: ['alias'],
   });
 
-
-  public findFactory = this.makeRequest<
-    {providerId: string},
-    any
-  >({
+  public findFactory = this.makeRequest<{providerId: string}, any>({
     method: 'GET',
     path: '/providers/{providerId}',
     urlParamKeys: ['providerId'],
   });
-
 
   public findMappers = this.makeRequest<
     {alias: string},
@@ -79,8 +74,8 @@ export class IdentityProviders extends Resource<{realm?: string}> {
   });
 
   public updateMapper = this.makeUpdateRequest<
-    {alias: string, id: string},
-    IdentityProviderRepresentation,
+    {alias: string; id: string},
+    IdentityProviderMapperRepresentation,
     void
   >({
     method: 'PUT',
@@ -88,12 +83,11 @@ export class IdentityProviders extends Resource<{realm?: string}> {
     urlParamKeys: ['alias', 'id'],
   });
 
-  public delMapper = this.makeRequest<{alias: string, id: string}, void>({
+  public delMapper = this.makeRequest<{alias: string; id: string}, void>({
     method: 'DELETE',
     path: '/instances/{alias}/mappers/{id}',
     urlParamKeys: ['alias', 'id'],
   });
-
 
   public findMapperTypes = this.makeRequest<
     {alias: string},

--- a/test/idp.spec.ts
+++ b/test/idp.spec.ts
@@ -56,6 +56,9 @@ describe('Identity providers', function() {
         id: idpMapperId,
       },
     );
+	
+	// check idp mapper deleted
+    expect(idpMapperUpdated).to.be.null;
 
     await this.kcAdminClient.identityProviders.del({
       alias: this.currentIdpAlias,
@@ -65,8 +68,7 @@ describe('Identity providers', function() {
       alias: this.currentIdpAlias,
     });
 
-    // check idp and idp mapper deleted
-    expect(idp).to.be.null;
+    // check idp deleted
     expect(idp).to.be.null;
   });
 

--- a/test/idp.spec.ts
+++ b/test/idp.spec.ts
@@ -25,18 +25,48 @@ describe('Identity providers', function() {
       providerId: 'saml',
     });
     this.currentIdpAlias = alias;
+
+    // create idp mapper
+    const mapper = {
+      name: 'First Name',
+      identityProviderAlias: this.currentIdpAlias,
+      identityProviderMapper: 'saml-user-attribute-idp-mapper',
+      config: {},
+    };
+    await this.kcAdminClient.identityProviders.createMapper({
+      alias: this.currentIdpAlias,
+      identityProviderMapper: mapper,
+    });
   });
 
   after(async () => {
+    const idpMapper = await this.kcAdminClient.identityProviders.findMappers({
+      alias: this.currentIdpAlias,
+    });
+
+    const idpMapperId = idpMapper[0].id;
+    await this.kcAdminClient.identityProviders.delMapper({
+      alias: this.currentIdpAlias,
+      id: idpMapperId,
+    });
+
+    const idpMapperUpdated = await this.kcAdminClient.identityProviders.findMappers(
+      {
+        alias: this.currentIdpAlias,
+      },
+    );
+
     await this.kcAdminClient.identityProviders.del({
       alias: this.currentIdpAlias,
     });
 
-    // check deleted
     const idp = await this.kcAdminClient.identityProviders.findOne({
       alias: this.currentIdpAlias,
     });
+
+    // check idp and idp mapper deleted
     expect(idp).to.be.null;
+    expect(idpMapperUpdated.length).to.equal(0);
   });
 
   it('list idp', async () => {
@@ -74,5 +104,50 @@ describe('Identity providers', function() {
       alias: this.currentIdpAlias,
       displayName: 'test',
     });
+  });
+
+  it('list idp factory', async () => {
+    const idpFactory = await this.kcAdminClient.identityProviders.findFactory({
+      providerId: 'saml',
+    });
+
+    expect(idpFactory).to.include({
+      id: 'saml',
+    });
+  });
+
+  it('get an idp mapper', async () => {
+    const mappers = await this.kcAdminClient.identityProviders.findMappers({
+      alias: this.currentIdpAlias,
+    });
+    expect(mappers.length).to.be.least(1);
+  });
+
+  it('update an idp mapper', async () => {
+    const idpMapper = await this.kcAdminClient.identityProviders.findMappers({
+      alias: this.currentIdpAlias,
+    });
+    const idpMapperId = idpMapper[0].id;
+
+    await this.kcAdminClient.identityProviders.updateMapper(
+      {alias: this.currentIdpAlias, id: idpMapperId},
+      {
+        id: idpMapperId,
+        identityProviderAlias: this.currentIdpAlias,
+        identityProviderMapper: 'saml-user-attribute-idp-mapper',
+        config: {
+          'user.attribute': 'firstName',
+        },
+      },
+    );
+
+    const updatedIdpMappers = await this.kcAdminClient.identityProviders.findMappers(
+      {
+        alias: this.currentIdpAlias,
+      },
+    );
+
+    const userAttribute = updatedIdpMappers[0].config['user.attribute'];
+    expect(userAttribute).to.equal('firstName');
   });
 });

--- a/test/idp.spec.ts
+++ b/test/idp.spec.ts
@@ -50,9 +50,10 @@ describe('Identity providers', function() {
       id: idpMapperId,
     });
 
-    const idpMapperUpdated = await this.kcAdminClient.identityProviders.findMappers(
+    const idpMapperUpdated = await this.kcAdminClient.identityProviders.findOneMapper(
       {
         alias: this.currentIdpAlias,
+        id: idpMapperId,
       },
     );
 
@@ -66,7 +67,7 @@ describe('Identity providers', function() {
 
     // check idp and idp mapper deleted
     expect(idp).to.be.null;
-    expect(idpMapperUpdated.length).to.equal(0);
+    expect(idp).to.be.null;
   });
 
   it('list idp', async () => {
@@ -141,13 +142,14 @@ describe('Identity providers', function() {
       },
     );
 
-    const updatedIdpMappers = await this.kcAdminClient.identityProviders.findMappers(
+    const updatedIdpMappers = await this.kcAdminClient.identityProviders.findOneMapper(
       {
         alias: this.currentIdpAlias,
+        id: idpMapperId,
       },
     );
 
-    const userAttribute = updatedIdpMappers[0].config['user.attribute'];
+    const userAttribute = updatedIdpMappers.config['user.attribute'];
     expect(userAttribute).to.equal('firstName');
   });
 });


### PR DESCRIPTION
This PR is to add the mappers to the identity providers.
It's important in order to make an IDP fully functional, in instance for ADFS I needed them to map all the user properties.