### PR TITLE
Add support for Client Scopes, Scope Mappings  and Protocol Mappers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# NODE
+node_modules
+
+# IDE
+.vscode
+
+# GITHUB
+.github

--- a/README.md
+++ b/README.md
@@ -252,6 +252,38 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Add optional client scope (`PUT /{realm}/clients/{id}/optional-client-scopes/{clientScopeId}`)
 - Delete optional client scope (`DELETE /{realm}/clients/{id}/optional-client-scopes/{clientScopeId}`)
 
+### [Scope Mappings for client scopes](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_scope_mappings_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Get all scope mappings for the client (`GET /{realm}/client-scopes/{id}/scope-mappings`)
+- Add client-level roles to the client’s scope (`POST /{realm}/client-scopes/{id}/scope-mappings/clients/{client}`)
+- Get the roles associated with a client’s scope (`GET /{realm}/client-scopes/{id}/scope-mappings/clients/{client}`)
+- The available client-level roles (`GET /{realm}/client-scopes/{id}/scope-mappings/clients/{client}/available`)
+- Get effective client roles (`GET /{realm}/client-scopes/{id}/scope-mappings/clients/{client}/composite`)
+- Remove client-level roles from the client’s scope. (`DELETE /{realm}/client-scopes/{id}/scope-mappings/clients/{client}`)
+- Add a set of realm-level roles to the client’s scope (`POST /{realm}/client-scopes/{id}/scope-mappings/realm`)
+- Get realm-level roles associated with the client’s scope (`GET /{realm}/client-scopes/{id}/scope-mappings/realm`)
+- Remove a set of realm-level roles from the client’s scope (`DELETE /{realm}/client-scopes/{id}/scope-mappings/realm`)
+- Get realm-level roles that are available to attach to this client’s scope (`GET /{realm}/client-scopes/{id}/scope-mappings/realm/available`)
+- Get effective realm-level roles associated with the client’s scope (`GET /{realm}/client-scopes/{id}/scope-mappings/realm/composite`)
+
+### [Scope Mappings for clients](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_scope_mappings_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Get all scope mappings for the client (`GET /{realm}/clients/{id}/scope-mappings`)
+- Add client-level roles to the client’s scope (`POST /{realm}/clients/{id}/scope-mappings/clients/{client}`)
+- Get the roles associated with a client’s scope (`GET /{realm}/clients/{id}/scope-mappings/clients/{client}`)
+- Remove client-level roles from the client’s scope. (`DELETE /{realm}/clients/{id}/scope-mappings/clients/{client}`)
+- The available client-level roles (`GET /{realm}/clients/{id}/scope-mappings/clients/{client}/available`)
+- Get effective client roles (`GET /{realm}/clients/{id}/scope-mappings/clients/{client}/composite`)
+- Add a set of realm-level roles to the client’s scope (`POST /{realm}/clients/{id}/scope-mappings/realm`)
+- Get realm-level roles associated with the client’s scope (`GET /{realm}/clients/{id}/scope-mappings/realm`)
+- Remove a set of realm-level roles from the client’s scope (`DELETE /{realm}/clients/{id}/scope-mappings/realm`)
+- Get realm-level roles that are available to attach to this client’s scope (`GET /{realm}/clients/{id}/scope-mappings/realm/available`)
+- Get effective realm-level roles associated with the client’s scope (`GET /{realm}/clients/{id}/scope-mappings/realm/composite`)
+
 ### [Protocol Mappers for client scopes](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_protocol_mappers_resource)
 
 Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts

--- a/README.md
+++ b/README.md
@@ -326,7 +326,6 @@ Supported for [user federation](https://www.keycloak.org/docs/latest/server_admi
 - [Client Initial Access](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_initial_access_resource)
 - [Client Registration Policy](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_registration_policy_resource)
 - [Key](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_key_resource)
-- [Scope Mappings](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_scope_mappings_resource)
 - [User Storage Provider](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_user_storage_provider_resource)
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -220,6 +220,62 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Delete the identity provider mapper (`DELETE /{realm}/identity-provider/instances/{alias}/mappers/{id}`)
 - Find the identity provider mapper types (`GET /{realm}/identity-provider/instances/{alias}/mapper-types`)
 
+### [Client Scopes](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_client_scopes_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Create a new client scope (`POST /{realm}/client-scopes`)
+- Get client scopes belonging to the realm (`GET /{realm}/client-scopes`)
+- Get representation of the client scope (`GET /{realm}/client-scopes/{id}`)
+- Update the client scope (`PUT /{realm}/client-scopes/{id}`)
+- Delete the client scope (`DELETE /{realm}/client-scopes/{id}`)
+
+### [Client Scopes for realm](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_client_scopes_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Get realm default client scopes (`GET /{realm}/default-default-client-scopes`)
+- Add realm default client scope (`PUT /{realm}/default-default-client-scopes/{id}`)
+- Delete realm default client scope (`DELETE /{realm}/default-default-client-scopes/{id}`)
+- Get realm optional client scopes (`GET /{realm}/default-optional-client-scopes`)
+- Add realm optional client scope (`PUT /{realm}/default-optional-client-scopes/{id}`)
+- Delete realm optional client scope (`DELETE /{realm}/default-optional-client-scopes/{id}`)
+
+### [Client Scopes for client](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_client_scopes_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Get default client scopes (`GET /{realm}/clients/{id}/default-client-scopes`)
+- Add default client scope (`PUT /{realm}/clients/{id}/default-client-scopes/{clientScopeId}`)
+- Delete default client scope (`DELETE /{realm}/clients/{id}/default-client-scopes/{clientScopeId}`)
+- Get optional client scopes (`GET /{realm}/clients/{id}/optional-client-scopes`)
+- Add optional client scope (`PUT /{realm}/clients/{id}/optional-client-scopes/{clientScopeId}`)
+- Delete optional client scope (`DELETE /{realm}/clients/{id}/optional-client-scopes/{clientScopeId}`)
+
+### [Protocol Mappers for client scopes](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_protocol_mappers_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clientScopes.spec.ts
+
+- Create multiple mappers (`POST /{realm}/client-scopes/{id}/protocol-mappers/add-models`)
+- Create a mapper (`POST /{realm}/client-scopes/{id}/protocol-mappers/models`)
+- Get mappers (`GET /{realm}/client-scopes/{id}/protocol-mappers/models`)
+- Get mapper by id (`GET /{realm}/client-scopes/{id}/protocol-mappers/models/{mapperId}`)
+- Update the mapper (`PUT /{realm}/client-scopes/{id}/protocol-mappers/models/{mapperId}`)
+- Delete the mapper (`DELETE /{realm}/client-scopes/{id}/protocol-mappers/models/{mapperId}`)
+- Get mappers by name for a specific protocol (`GET /{realm}/client-scopes/{id}/protocol-mappers/protocol/{protocol}`)
+
+### [Protocol Mappers for clients](https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_protocol_mappers_resource)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clients.spec.ts
+
+- Create multiple mappers (`POST /{realm}/clients/{id}/protocol-mappers/add-models`)
+- Create a mapper (`POST /{realm}/clients/{id}/protocol-mappers/models`)
+- Get mappers (`GET /{realm}/clients/{id}/protocol-mappers/models`)
+- Get mapper by id (`GET /{realm}/clients/{id}/protocol-mappers/models/{mapperId}`)
+- Update the mapper (`PUT /{realm}/clients/{id}/protocol-mappers/models/{mapperId}`)
+- Delete the mapper (`DELETE /{realm}/clients/{id}/protocol-mappers/models/{mapperId}`)
+- Get mappers by name for a specific protocol (`GET /{realm}/clients/{id}/protocol-mappers/protocol/{protocol}`)
+
 ### [Component]()
 
 Supported for [user federation](https://www.keycloak.org/docs/latest/server_admin/index.html#_user-storage-federation). Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/components.spec.ts
@@ -237,9 +293,7 @@ Supported for [user federation](https://www.keycloak.org/docs/latest/server_admi
 - [Client Attribute Certificate](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_attribute_certificate_resource)
 - [Client Initial Access](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_initial_access_resource)
 - [Client Registration Policy](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_registration_policy_resource)
-- [Client Scopes](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_client_scopes_resource)
 - [Key](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_key_resource)
-- [Protocol Mappers](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_protocol_mappers_resource)
 - [Scope Mappings](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_scope_mappings_resource)
 - [User Storage Provider](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_user_storage_provider_resource)
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@ import {Groups} from './resources/groups';
 import {Roles} from './resources/roles';
 import {Clients} from './resources/clients';
 import {Realms} from './resources/realms';
+import {ClientScopes} from './resources/clientScopes';
 import {IdentityProviders} from './resources/identityProviders';
 import {Components} from './resources/components';
 import {AxiosRequestConfig} from 'axios';
@@ -22,6 +23,7 @@ export class KeycloakAdminClient {
   public roles: Roles;
   public clients: Clients;
   public realms: Realms;
+  public clientScopes: ClientScopes;
   public identityProviders: IdentityProviders;
   public components: Components;
 
@@ -45,6 +47,7 @@ export class KeycloakAdminClient {
     this.roles = new Roles(this);
     this.clients = new Clients(this);
     this.realms = new Realms(this);
+    this.clientScopes = new ClientScopes(this);
     this.identityProviders = new IdentityProviders(this);
     this.components = new Components(this);
   }

--- a/src/defs/clientScopeRepresentation.ts
+++ b/src/defs/clientScopeRepresentation.ts
@@ -1,0 +1,13 @@
+/**
+ * https://www.keycloak.org/docs-api/6.0/rest-api/index.html#_clientscoperepresentation
+ */
+import ProtocolMapperRepresentation from './protocolMapperRepresentation';
+
+export default interface ClientScopeRepresentation {
+  attributes?: Record<string, any>;
+  description?: string;
+  id?: string;
+  name?: string;
+  protocol?: string;
+  protocolMappers?: ProtocolMapperRepresentation[];
+}

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -4,7 +4,7 @@ import {KeycloakAdminClient} from '../client';
 import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
 
 export class ClientScopes extends Resource<{realm?: string}> {
-  public find = this.makeRequest<void, ClientScopeRepresentation[]>({
+  public find = this.makeRequest<{}, ClientScopeRepresentation[]>({
     method: 'GET',
     path: '/client-scopes',
   });
@@ -178,17 +178,23 @@ export class ClientScopes extends Resource<{realm?: string}> {
    * Find client scope by name.
    */
   public async findOneByName(payload: {
+    realm?: string;
     name: string;
   }): Promise<ClientScopeRepresentation> {
-    const allScopes = await this.find();
+    const allScopes = await this.find({
+      ...(payload.realm ? {realm: payload.realm} : {}),
+    });
     const scope = allScopes.find(item => item.name === payload.name);
     return scope ? scope : null;
   }
 
   /**
-   * Find client scope by name.
+   * Delete client scope by name.
    */
-  public async delByName(payload: {name: string}): Promise<void> {
+  public async delByName(payload: {
+    realm?: string;
+    name: string;
+  }): Promise<void> {
     const scope = await this.findOneByName(payload);
 
     if (!scope) {
@@ -202,11 +208,13 @@ export class ClientScopes extends Resource<{realm?: string}> {
    * Find single protocol mapper by name.
    */
   public async findProtocolMapperByName(payload: {
+    realm?: string;
     id: string;
     name: string;
   }): Promise<ProtocolMapperRepresentation> {
     const allProtocolMappers = await this.listProtocolMappers({
       id: payload.id,
+      ...(payload.realm ? {realm: payload.realm} : {}),
     });
     const protocolMapper = allProtocolMappers.find(
       mapper => mapper.name === payload.name,

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -1,0 +1,216 @@
+import ClientScopeRepresentation from '../defs/clientScopeRepresentation';
+import Resource from './resource';
+import {KeycloakAdminClient} from '../client';
+import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
+
+export class ClientScopes extends Resource<{realm?: string}> {
+  public find = this.makeRequest<void, ClientScopeRepresentation[]>({
+    method: 'GET',
+    path: '/client-scopes',
+  });
+
+  public create = this.makeRequest<ClientScopeRepresentation, void>({
+    method: 'POST',
+    path: '/client-scopes',
+  });
+
+  /**
+   * Client-Scopes by id
+   */
+
+  public findOneById = this.makeRequest<
+    {id: string},
+    ClientScopeRepresentation
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}',
+    urlParamKeys: ['id'],
+    catchNotFound: true,
+  });
+
+  public updateById = this.makeUpdateRequest<
+    {id: string},
+    ClientScopeRepresentation,
+    void
+  >({
+    method: 'PUT',
+    path: '/client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  public delById = this.makeRequest<{id: string}, void>({
+    method: 'DELETE',
+    path: '/client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  /**
+   * Default Client-Scopes
+   */
+
+  public listDefaultClientScopes = this.makeRequest<
+    void,
+    ClientScopeRepresentation[]
+  >({
+    method: 'GET',
+    path: '/default-default-client-scopes',
+  });
+
+  public addDefaultClientScope = this.makeRequest<{id: string}, void>({
+    method: 'PUT',
+    path: '/default-default-client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  public delDefaultClientScope = this.makeRequest<{id: string}, void>({
+    method: 'DELETE',
+    path: '/default-default-client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  /**
+   * Default Optional Client-Scopes
+   */
+
+  public listDefaultOptionalClientScopes = this.makeRequest<
+    void,
+    ClientScopeRepresentation[]
+  >({
+    method: 'GET',
+    path: '/default-optional-client-scopes',
+  });
+
+  public addDefaultOptionalClientScope = this.makeRequest<{id: string}, void>({
+    method: 'PUT',
+    path: '/default-optional-client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  public delDefaultOptionalClientScope = this.makeRequest<{id: string}, void>({
+    method: 'DELETE',
+    path: '/default-optional-client-scopes/{id}',
+    urlParamKeys: ['id'],
+  });
+
+  /**
+   * Protocol Mappers
+   */
+
+  public addMultipleProtocolMappers = this.makeUpdateRequest<
+    {id: string},
+    ProtocolMapperRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/client-scopes/{id}/protocol-mappers/add-models',
+    urlParamKeys: ['id'],
+  });
+
+  public addProtocolMapper = this.makeUpdateRequest<
+    {id: string},
+    ProtocolMapperRepresentation,
+    void
+  >({
+    method: 'POST',
+    path: '/client-scopes/{id}/protocol-mappers/models',
+    urlParamKeys: ['id'],
+  });
+
+  public listProtocolMappers = this.makeRequest<
+    {id: string},
+    ProtocolMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/protocol-mappers/models',
+    urlParamKeys: ['id'],
+  });
+
+  public findProtocolMapperById = this.makeRequest<
+    {id: string; mapperId: string},
+    ProtocolMapperRepresentation
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+    catchNotFound: true,
+  });
+
+  public findProtocolMappersByProtocol = this.makeRequest<
+    {id: string; protocol: string},
+    ProtocolMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/protocol-mappers/protocol/{protocol}',
+    urlParamKeys: ['id', 'protocol'],
+    catchNotFound: true,
+  });
+
+  public updateProtocolMapper = this.makeUpdateRequest<
+    {id: string; mapperId: string},
+    ProtocolMapperRepresentation,
+    void
+  >({
+    method: 'PUT',
+    path: '/client-scopes/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+  });
+
+  public delProtocolMapper = this.makeRequest<
+    {id: string; mapperId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/client-scopes/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+  });
+
+  constructor(client: KeycloakAdminClient) {
+    super(client, {
+      path: '/admin/realms/{realm}',
+      getUrlParams: () => ({
+        realm: client.realmName,
+      }),
+      getBaseUrl: () => client.baseUrl,
+    });
+  }
+
+  /**
+   * Find client scope by name.
+   */
+  public async findOneByName(payload: {
+    name: string;
+  }): Promise<ClientScopeRepresentation> {
+    const allScopes = await this.find();
+    const scope = allScopes.find(item => item.name === payload.name);
+    return scope ? scope : null;
+  }
+
+  /**
+   * Find client scope by name.
+   */
+  public async delByName(payload: {name: string}): Promise<void> {
+    const scope = await this.findOneByName(payload);
+
+    if (!scope) {
+      throw new Error('Scope not found.');
+    }
+
+    await this.delById({id: scope.id});
+  }
+
+  /**
+   * Find single protocol mapper by name.
+   */
+  public async findProtocolMapperByName(payload: {
+    id: string;
+    name: string;
+  }): Promise<ProtocolMapperRepresentation> {
+    const allProtocolMappers = await this.listProtocolMappers({
+      id: payload.id,
+    });
+    const protocolMapper = allProtocolMappers.find(
+      mapper => mapper.name === payload.name,
+    );
+    return protocolMapper ? protocolMapper : null;
+  }
+}

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -309,7 +309,10 @@ export class ClientScopes extends Resource<{realm?: string}> {
       throw new Error('Scope not found.');
     }
 
-    await this.delById({id: scope.id});
+    await this.delById({
+      ...(payload.realm ? {realm: payload.realm} : {}),
+      id: scope.id,
+    });
   }
 
   /**

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -20,17 +20,14 @@ export class ClientScopes extends Resource<{realm?: string}> {
    * Client-Scopes by id
    */
 
-  public findOneById = this.makeRequest<
-    {id: string},
-    ClientScopeRepresentation
-  >({
+  public findOne = this.makeRequest<{id: string}, ClientScopeRepresentation>({
     method: 'GET',
     path: '/client-scopes/{id}',
     urlParamKeys: ['id'],
     catchNotFound: true,
   });
 
-  public updateById = this.makeUpdateRequest<
+  public update = this.makeUpdateRequest<
     {id: string},
     ClientScopeRepresentation,
     void
@@ -40,7 +37,7 @@ export class ClientScopes extends Resource<{realm?: string}> {
     urlParamKeys: ['id'],
   });
 
-  public delById = this.makeRequest<{id: string}, void>({
+  public del = this.makeRequest<{id: string}, void>({
     method: 'DELETE',
     path: '/client-scopes/{id}',
     urlParamKeys: ['id'],
@@ -127,7 +124,7 @@ export class ClientScopes extends Resource<{realm?: string}> {
     urlParamKeys: ['id'],
   });
 
-  public findProtocolMapperById = this.makeRequest<
+  public findProtocolMapper = this.makeRequest<
     {id: string; mapperId: string},
     ProtocolMapperRepresentation
   >({
@@ -309,7 +306,7 @@ export class ClientScopes extends Resource<{realm?: string}> {
       throw new Error('Scope not found.');
     }
 
-    await this.delById({
+    await this.del({
       ...(payload.realm ? {realm: payload.realm} : {}),
       id: scope.id,
     });

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -2,6 +2,8 @@ import ClientScopeRepresentation from '../defs/clientScopeRepresentation';
 import Resource from './resource';
 import {KeycloakAdminClient} from '../client';
 import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
+import MappingsRepresentation from '../defs/mappingsRepresentation';
+import RoleRepresentation from '../defs/roleRepresentation';
 
 export class ClientScopes extends Resource<{realm?: string}> {
   public find = this.makeRequest<{}, ClientScopeRepresentation[]>({
@@ -162,6 +164,112 @@ export class ClientScopes extends Resource<{realm?: string}> {
     method: 'DELETE',
     path: '/client-scopes/{id}/protocol-mappers/models/{mapperId}',
     urlParamKeys: ['id', 'mapperId'],
+  });
+
+  /**
+   * Scope Mappings
+   */
+  public listScopeMappings = this.makeRequest<
+    {id: string},
+    MappingsRepresentation
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings',
+    urlParamKeys: ['id'],
+  });
+
+  public addClientScopeMappings = this.makeUpdateRequest<
+    {id: string; client: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/client-scopes/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listAvailableClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/clients/{client}/available',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listCompositeClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/clients/{client}/available',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public delClientScopeMappings = this.makeUpdateRequest<
+    {id: string; client: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'DELETE',
+    path: '/client-scopes/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public addRealmScopeMappings = this.makeUpdateRequest<
+    {id: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/client-scopes/{id}/scope-mappings/realm',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/realm',
+    urlParamKeys: ['id'],
+  });
+
+  public listAvailableRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/realm/available',
+    urlParamKeys: ['id'],
+  });
+
+  public listCompositeRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/client-scopes/{id}/scope-mappings/realm/available',
+    urlParamKeys: ['id'],
+  });
+
+  public delRealmScopeMappings = this.makeUpdateRequest<
+    {id: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'DELETE',
+    path: '/client-scopes/{id}/scope-mappings/realm',
+    urlParamKeys: ['id'],
   });
 
   constructor(client: KeycloakAdminClient) {

--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -232,7 +232,7 @@ export class ClientScopes extends Resource<{realm?: string}> {
   >({
     method: 'POST',
     path: '/client-scopes/{id}/scope-mappings/realm',
-    urlParamKeys: ['id', 'client'],
+    urlParamKeys: ['id'],
   });
 
   public listRealmScopeMappings = this.makeRequest<

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -4,6 +4,8 @@ import {KeycloakAdminClient} from '../client';
 import RoleRepresentation from '../defs/roleRepresentation';
 import UserRepresentation from '../defs/userRepresentation';
 import CredentialRepresentation from '../defs/credentialRepresentation';
+import ClientScopeRepresentation from '../defs/clientScopeRepresentation';
+import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
 
 export interface ClientQuery {
   clientId?: string;
@@ -133,6 +135,135 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id'],
   });
 
+  /**
+   * Client Scopes
+   */
+  public listDefaultClientScopes = this.makeRequest<
+    {id: string},
+    ClientScopeRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/default-client-scopes',
+    urlParamKeys: ['id'],
+  });
+
+  public addDefaultClientScope = this.makeRequest<
+    {id: string; clientScopeId: string},
+    void
+  >({
+    method: 'PUT',
+    path: '/{id}/default-client-scopes/{clientScopeId}',
+    urlParamKeys: ['id', 'clientScopeId'],
+  });
+
+  public delDefaultClientScope = this.makeRequest<
+    {id: string; clientScopeId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/default-client-scopes/{clientScopeId}',
+    urlParamKeys: ['id', 'clientScopeId'],
+  });
+
+  public listOptionalClientScopes = this.makeRequest<
+    {id: string},
+    ClientScopeRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/optional-client-scopes',
+    urlParamKeys: ['id'],
+  });
+
+  public addOptionalClientScope = this.makeRequest<
+    {id: string; clientScopeId: string},
+    void
+  >({
+    method: 'PUT',
+    path: '/{id}/optional-client-scopes/{clientScopeId}',
+    urlParamKeys: ['id', 'clientScopeId'],
+  });
+
+  public delOptionalClientScope = this.makeRequest<
+    {id: string; clientScopeId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/optional-client-scopes/{clientScopeId}',
+    urlParamKeys: ['id', 'clientScopeId'],
+  });
+
+  /**
+   * Protocol Mappers
+   */
+
+  public addMultipleProtocolMappers = this.makeUpdateRequest<
+    {id: string},
+    ProtocolMapperRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/protocol-mappers/add-models',
+    urlParamKeys: ['id'],
+  });
+
+  public addProtocolMapper = this.makeUpdateRequest<
+    {id: string},
+    ProtocolMapperRepresentation,
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/protocol-mappers/models',
+    urlParamKeys: ['id'],
+  });
+
+  public listProtocolMappers = this.makeRequest<
+    {id: string},
+    ProtocolMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/protocol-mappers/models',
+    urlParamKeys: ['id'],
+  });
+
+  public findProtocolMapperById = this.makeRequest<
+    {id: string; mapperId: string},
+    ProtocolMapperRepresentation
+  >({
+    method: 'GET',
+    path: '/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+    catchNotFound: true,
+  });
+
+  public findProtocolMappersByProtocol = this.makeRequest<
+    {id: string; protocol: string},
+    ProtocolMapperRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/protocol-mappers/protocol/{protocol}',
+    urlParamKeys: ['id', 'protocol'],
+    catchNotFound: true,
+  });
+
+  public updateProtocolMapper = this.makeUpdateRequest<
+    {id: string; mapperId: string},
+    ProtocolMapperRepresentation,
+    void
+  >({
+    method: 'PUT',
+    path: '/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+  });
+
+  public delProtocolMapper = this.makeRequest<
+    {id: string; mapperId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/protocol-mappers/models/{mapperId}',
+    urlParamKeys: ['id', 'mapperId'],
+  });
+
   constructor(client: KeycloakAdminClient) {
     super(client, {
       path: '/admin/realms/{realm}/clients',
@@ -141,5 +272,21 @@ export class Clients extends Resource<{realm?: string}> {
       }),
       getBaseUrl: () => client.baseUrl,
     });
+  }
+
+  /**
+   * Find single protocol mapper by name.
+   */
+  public async findProtocolMapperByName(payload: {
+    id: string;
+    name: string;
+  }): Promise<ProtocolMapperRepresentation> {
+    const allProtocolMappers = await this.listProtocolMappers({
+      id: payload.id,
+    });
+    const protocolMapper = allProtocolMappers.find(
+      mapper => mapper.name === payload.name,
+    );
+    return protocolMapper ? protocolMapper : null;
   }
 }

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -6,6 +6,7 @@ import UserRepresentation from '../defs/userRepresentation';
 import CredentialRepresentation from '../defs/credentialRepresentation';
 import ClientScopeRepresentation from '../defs/clientScopeRepresentation';
 import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
+import MappingsRepresentation from '../defs/mappingsRepresentation';
 
 export interface ClientQuery {
   clientId?: string;
@@ -262,6 +263,112 @@ export class Clients extends Resource<{realm?: string}> {
     method: 'DELETE',
     path: '/{id}/protocol-mappers/models/{mapperId}',
     urlParamKeys: ['id', 'mapperId'],
+  });
+
+  /**
+   * Scope Mappings
+   */
+  public listScopeMappings = this.makeRequest<
+    {id: string},
+    MappingsRepresentation
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings',
+    urlParamKeys: ['id'],
+  });
+
+  public addClientScopeMappings = this.makeUpdateRequest<
+    {id: string; client: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listAvailableClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/clients/{client}/available',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listCompositeClientScopeMappings = this.makeRequest<
+    {id: string; client: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/clients/{client}/available',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public delClientScopeMappings = this.makeUpdateRequest<
+    {id: string; client: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/scope-mappings/clients/{client}',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public addRealmScopeMappings = this.makeUpdateRequest<
+    {id: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/scope-mappings/realm',
+    urlParamKeys: ['id', 'client'],
+  });
+
+  public listRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/realm',
+    urlParamKeys: ['id'],
+  });
+
+  public listAvailableRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/realm/available',
+    urlParamKeys: ['id'],
+  });
+
+  public listCompositeRealmScopeMappings = this.makeRequest<
+    {id: string},
+    RoleRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/scope-mappings/realm/available',
+    urlParamKeys: ['id'],
+  });
+
+  public delRealmScopeMappings = this.makeUpdateRequest<
+    {id: string},
+    RoleRepresentation[],
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/scope-mappings/realm',
+    urlParamKeys: ['id'],
   });
 
   constructor(client: KeycloakAdminClient) {

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -278,11 +278,13 @@ export class Clients extends Resource<{realm?: string}> {
    * Find single protocol mapper by name.
    */
   public async findProtocolMapperByName(payload: {
+    realm?: string;
     id: string;
     name: string;
   }): Promise<ProtocolMapperRepresentation> {
     const allProtocolMappers = await this.listProtocolMappers({
       id: payload.id,
+      ...(payload.realm ? {realm: payload.realm} : {}),
     });
     const protocolMapper = allProtocolMappers.find(
       mapper => mapper.name === payload.name,

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -565,28 +565,20 @@ describe('Client Scopes', () => {
         const {id} = this.currentClientScope;
 
         const availableRoles = await this.kcAdminClient.clientScopes.listAvailableRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
 
         await this.kcAdminClient.clientScopes.addRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
           availableRoles,
         );
 
         const roles = await this.kcAdminClient.clientScopes.listRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
 
         expect(roles).to.be.ok;
-        expect(roles.sort((a, b) => (a.name < b.name ? -1 : 1))).to.be.eql(
-          availableRoles.sort((a, b) => (a.name < b.name ? -1 : 1)),
-        );
+        expect(roles).to.deep.members(availableRoles);
       });
 
       it('list scope mappings', async () => {

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -1,0 +1,395 @@
+// tslint:disable:no-unused-expression
+import * as chai from 'chai';
+import {KeycloakAdminClient} from '../src/client';
+import {credentials} from './constants';
+import ClientScopeRepresentation from '../src/defs/clientScopeRepresentation';
+import ProtocolMapperRepresentation from '../src/defs/protocolMapperRepresentation';
+
+const expect = chai.expect;
+
+declare module 'mocha' {
+  // tslint:disable-next-line:interface-name
+  interface ISuiteCallbackContext {
+    kcAdminClient?: KeycloakAdminClient;
+    currentClientScope?: ClientScopeRepresentation;
+    clientScopeName?: string;
+  }
+}
+
+describe('Client Scopes', () => {
+  before(async () => {
+    this.kcAdminClient = new KeycloakAdminClient();
+    await this.kcAdminClient.auth(credentials);
+  });
+
+  beforeEach(async () => {
+    this.clientScopeName = 'best-of-the-bests-scope';
+    await this.kcAdminClient.clientScopes.create({name: this.clientScopeName});
+    this.currentClientScope = await this.kcAdminClient.clientScopes.findOneByName(
+      {
+        name: this.clientScopeName,
+      },
+    );
+  });
+
+  afterEach(async () => {
+    // cleanup default client scopes
+    try {
+      await this.kcAdminClient.clientScopes.delDefaultClientScope({
+        id: this.currentClientScope.id,
+      });
+    } catch (e) {
+      // ignore
+    }
+
+    // cleanup optional client scopes
+    try {
+      await this.kcAdminClient.clientScopes.delDefaultOptionalClientScope({
+        id: this.currentClientScope.id,
+      });
+    } catch (e) {
+      // ignore
+    }
+
+    // cleanup client scopes
+    try {
+      await this.kcAdminClient.clientScopes.delByName({
+        name: this.clientScopeName,
+      });
+    } catch (e) {
+      // ignore
+    }
+  });
+
+  it('list client scopes', async () => {
+    const scopes = await this.kcAdminClient.clientScopes.find();
+    expect(scopes).to.be.ok;
+  });
+
+  it('create client scope and get by name', async () => {
+    // ensure that the scope does not exist
+    try {
+      await this.kcAdminClient.clientScopes.delByName({
+        name: this.clientScopeName,
+      });
+    } catch (e) {
+      // ignore
+    }
+
+    await this.kcAdminClient.clientScopes.create({name: this.clientScopeName});
+
+    const scope = await this.kcAdminClient.clientScopes.findOneByName({
+      name: this.clientScopeName,
+    });
+    expect(scope).to.be.ok;
+    expect(scope.name).to.equal(this.clientScopeName);
+  });
+
+  it('find scope by id', async () => {
+    const scope = await this.kcAdminClient.clientScopes.findOneById({
+      id: this.currentClientScope.id,
+    });
+    expect(scope).to.be.ok;
+    expect(scope).to.eql(this.currentClientScope);
+  });
+
+  it('find scope by name', async () => {
+    const scope = await this.kcAdminClient.clientScopes.findOneByName({
+      name: this.clientScopeName,
+    });
+    expect(scope).to.be.ok;
+    expect(scope.name).to.eql(this.clientScopeName);
+  });
+
+  it('return null if scope not found by id', async () => {
+    const scope = await this.kcAdminClient.clientScopes.findOneById({
+      id: 'I do not exist',
+    });
+    expect(scope).to.be.null;
+  });
+
+  it('return null if scope not found by name', async () => {
+    const scope = await this.kcAdminClient.clientScopes.findOneByName({
+      name: 'I do not exist',
+    });
+    expect(scope).to.be.null;
+  });
+
+  it('update client scope', async () => {
+    const {id, description: oldDescription} = this.currentClientScope;
+    const description = 'This scope is totally awesome.';
+
+    await this.kcAdminClient.clientScopes.updateById({id}, {description});
+    const updatedScope = await this.kcAdminClient.clientScopes.findOneById({
+      id,
+    });
+    expect(updatedScope).to.be.ok;
+    expect(updatedScope).not.to.eql(this.currentClientScope);
+    expect(updatedScope.description).to.eq(description);
+    expect(updatedScope.description).not.to.eq(oldDescription);
+  });
+
+  it('delete single client scope by id', async () => {
+    await this.kcAdminClient.clientScopes.delById({
+      id: this.currentClientScope.id,
+    });
+    const scope = await this.kcAdminClient.clientScopes.findOneById({
+      id: this.currentClientScope.id,
+    });
+    expect(scope).not.to.be.ok;
+  });
+
+  it('delete single client scope by name', async () => {
+    await this.kcAdminClient.clientScopes.delByName({
+      name: this.clientScopeName,
+    });
+    const scope = await this.kcAdminClient.clientScopes.findOneByName({
+      name: this.clientScopeName,
+    });
+    expect(scope).not.to.be.ok;
+  });
+
+  describe('default client scope', () => {
+    it('list default client scopes', async () => {
+      const defaultClientScopes = await this.kcAdminClient.clientScopes.listDefaultClientScopes();
+      expect(defaultClientScopes).to.be.ok;
+    });
+
+    it('add default client scope', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addDefaultClientScope({id});
+
+      const defaultClientScopeList = await this.kcAdminClient.clientScopes.listDefaultClientScopes();
+      const defaultClientScope = defaultClientScopeList.find(
+        scope => scope.id === id,
+      );
+
+      expect(defaultClientScope).to.be.ok;
+      expect(defaultClientScope.id).to.equal(this.currentClientScope.id);
+      expect(defaultClientScope.name).to.equal(this.currentClientScope.name);
+    });
+
+    it('delete default client scope', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addDefaultClientScope({id});
+
+      await this.kcAdminClient.clientScopes.delDefaultClientScope({id});
+
+      const defaultClientScopeList = await this.kcAdminClient.clientScopes.listDefaultClientScopes();
+      const defaultClientScope = defaultClientScopeList.find(
+        scope => scope.id === id,
+      );
+
+      expect(defaultClientScope).not.to.be.ok;
+    });
+  });
+
+  describe('default optional client scopes', () => {
+    it('list default optional client scopes', async () => {
+      const defaultOptionalClientScopes = await this.kcAdminClient.clientScopes.listDefaultOptionalClientScopes();
+      expect(defaultOptionalClientScopes).to.be.ok;
+    });
+
+    it('add default optional client scope', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addDefaultOptionalClientScope({id});
+
+      const defaultOptionalClientScopeList = await this.kcAdminClient.clientScopes.listDefaultOptionalClientScopes();
+      const defaultOptionalClientScope = defaultOptionalClientScopeList.find(
+        scope => scope.id === id,
+      );
+
+      expect(defaultOptionalClientScope).to.be.ok;
+      expect(defaultOptionalClientScope.id).to.eq(this.currentClientScope.id);
+      expect(defaultOptionalClientScope.name).to.eq(
+        this.currentClientScope.name,
+      );
+    });
+
+    it('delete default optional client scope', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addDefaultOptionalClientScope({id});
+      await this.kcAdminClient.clientScopes.delDefaultOptionalClientScope({id});
+
+      const defaultOptionalClientScopeList = await this.kcAdminClient.clientScopes.listDefaultOptionalClientScopes();
+      const defaultOptionalClientScope = defaultOptionalClientScopeList.find(
+        scope => scope.id === id,
+      );
+
+      expect(defaultOptionalClientScope).not.to.be.ok;
+    });
+  });
+
+  describe('protocol mappers', () => {
+    let dummyMapper: ProtocolMapperRepresentation;
+
+    beforeEach(() => {
+      dummyMapper = {
+        name: 'mapping-maps-mapper',
+        protocol: 'openid-connect',
+        protocolMapper: 'oidc-audience-mapper',
+      };
+    });
+
+    afterEach(async () => {
+      try {
+        const {id} = this.currentClientScope;
+        const {
+          id: mapperId,
+        } = await this.kcAdminClient.clientScopes.findProtocolMapperByName({
+          id,
+          name: dummyMapper.name,
+        });
+        await this.kcAdminClient.clientScopes.delProtocolMapper({
+          id,
+          mapperId,
+        });
+      } catch (e) {
+        // ignore
+      }
+    });
+
+    it('list protocol mappers', async () => {
+      const {id} = this.currentClientScope;
+      const mapperList = await this.kcAdminClient.clientScopes.listProtocolMappers(
+        {id},
+      );
+      expect(mapperList).to.be.ok;
+    });
+
+    it('add multiple protocol mappers', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addMultipleProtocolMappers({id}, [
+        dummyMapper,
+      ]);
+
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+      expect(mapper).to.be.ok;
+      expect(mapper.protocol).to.eq(dummyMapper.protocol);
+      expect(mapper.protocolMapper).to.eq(dummyMapper.protocolMapper);
+    });
+
+    it('add single protocol mapper', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+      expect(mapper).to.be.ok;
+      expect(mapper.protocol).to.eq(dummyMapper.protocol);
+      expect(mapper.protocolMapper).to.eq(dummyMapper.protocolMapper);
+    });
+
+    it('find protocol mapper by id', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+
+      const {
+        id: mapperId,
+      } = await this.kcAdminClient.clientScopes.findProtocolMapperByName({
+        id,
+        name: dummyMapper.name,
+      });
+
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperById(
+        {id, mapperId},
+      );
+
+      expect(mapper).to.be.ok;
+      expect(mapper.id).to.eql(mapperId);
+    });
+
+    it('find protocol mapper by name', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+
+      expect(mapper).to.be.ok;
+      expect(mapper.name).to.eql(dummyMapper.name);
+    });
+
+    it('find protocol mappers by protocol', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+
+      const mapperList = await this.kcAdminClient.clientScopes.findProtocolMappersByProtocol(
+        {id, protocol: dummyMapper.protocol},
+      );
+
+      expect(mapperList).to.be.ok;
+      expect(mapperList.length).to.be.gte(1);
+
+      const mapper = mapperList.find(item => item.name === dummyMapper.name);
+      expect(mapper).to.be.ok;
+    });
+
+    it('update protocol mapper', async () => {
+      const {id} = this.currentClientScope;
+
+      dummyMapper.config = {'access.token.claim': 'true'};
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+
+      expect(mapper.config['access.token.claim']).to.eq('true');
+
+      mapper.config = {'access.token.claim': 'false'};
+
+      await this.kcAdminClient.clientScopes.updateProtocolMapper(
+        {id, mapperId: mapper.id},
+        mapper,
+      );
+
+      const updatedMapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+
+      expect(updatedMapper.config['access.token.claim']).to.eq('false');
+    });
+
+    it('delete protocol mapper', async () => {
+      const {id} = this.currentClientScope;
+      await this.kcAdminClient.clientScopes.addProtocolMapper(
+        {id},
+        dummyMapper,
+      );
+
+      const {
+        id: mapperId,
+      } = await this.kcAdminClient.clientScopes.findProtocolMapperByName({
+        id,
+        name: dummyMapper.name,
+      });
+
+      await this.kcAdminClient.clientScopes.delProtocolMapper({id, mapperId});
+
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperByName(
+        {id, name: dummyMapper.name},
+      );
+
+      expect(mapper).not.to.be.ok;
+    });
+  });
+});

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -456,12 +456,14 @@ describe('Client Scopes', () => {
           },
         );
 
+        const filteredRoles = availableRoles.filter(role => !role.composite);
+
         await this.kcAdminClient.clientScopes.addClientScopeMappings(
           {
             id,
             client: clientUniqueId,
           },
-          availableRoles,
+          filteredRoles,
         );
 
         const roles = await this.kcAdminClient.clientScopes.listClientScopeMappings(
@@ -472,7 +474,7 @@ describe('Client Scopes', () => {
         );
 
         expect(roles).to.be.ok;
-        expect(roles).to.be.eql(availableRoles);
+        expect(roles).to.be.eql(filteredRoles);
       });
 
       it('list scope mappings', async () => {
@@ -568,9 +570,11 @@ describe('Client Scopes', () => {
           {id},
         );
 
+        const filteredRoles = availableRoles.filter(role => !role.composite);
+
         await this.kcAdminClient.clientScopes.addRealmScopeMappings(
           {id},
-          availableRoles,
+          filteredRoles,
         );
 
         const roles = await this.kcAdminClient.clientScopes.listRealmScopeMappings(
@@ -578,7 +582,7 @@ describe('Client Scopes', () => {
         );
 
         expect(roles).to.be.ok;
-        expect(roles).to.include.deep.members(availableRoles);
+        expect(roles).to.include.deep.members(filteredRoles);
       });
 
       it('list scope mappings', async () => {

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -578,7 +578,7 @@ describe('Client Scopes', () => {
         );
 
         expect(roles).to.be.ok;
-        expect(roles).to.deep.members(availableRoles);
+        expect(roles).to.include.deep.members(availableRoles);
       });
 
       it('list scope mappings', async () => {

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -92,7 +92,7 @@ describe('Client Scopes', () => {
   });
 
   it('find scope by id', async () => {
-    const scope = await this.kcAdminClient.clientScopes.findOneById({
+    const scope = await this.kcAdminClient.clientScopes.findOne({
       id: this.currentClientScope.id,
     });
     expect(scope).to.be.ok;
@@ -108,7 +108,7 @@ describe('Client Scopes', () => {
   });
 
   it('return null if scope not found by id', async () => {
-    const scope = await this.kcAdminClient.clientScopes.findOneById({
+    const scope = await this.kcAdminClient.clientScopes.findOne({
       id: 'I do not exist',
     });
     expect(scope).to.be.null;
@@ -125,8 +125,8 @@ describe('Client Scopes', () => {
     const {id, description: oldDescription} = this.currentClientScope;
     const description = 'This scope is totally awesome.';
 
-    await this.kcAdminClient.clientScopes.updateById({id}, {description});
-    const updatedScope = await this.kcAdminClient.clientScopes.findOneById({
+    await this.kcAdminClient.clientScopes.update({id}, {description});
+    const updatedScope = await this.kcAdminClient.clientScopes.findOne({
       id,
     });
     expect(updatedScope).to.be.ok;
@@ -136,10 +136,10 @@ describe('Client Scopes', () => {
   });
 
   it('delete single client scope by id', async () => {
-    await this.kcAdminClient.clientScopes.delById({
+    await this.kcAdminClient.clientScopes.del({
       id: this.currentClientScope.id,
     });
-    const scope = await this.kcAdminClient.clientScopes.findOneById({
+    const scope = await this.kcAdminClient.clientScopes.findOne({
       id: this.currentClientScope.id,
     });
     expect(scope).not.to.be.ok;
@@ -306,9 +306,10 @@ describe('Client Scopes', () => {
         name: dummyMapper.name,
       });
 
-      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapperById(
-        {id, mapperId},
-      );
+      const mapper = await this.kcAdminClient.clientScopes.findProtocolMapper({
+        id,
+        mapperId,
+      });
 
       expect(mapper).to.be.ok;
       expect(mapper.id).to.eql(mapperId);

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -438,7 +438,7 @@ describe('Clients', function() {
         protocol: 'openid-connect',
         protocolMapper: 'oidc-role-name-mapper',
         config: {
-          role: 'admin',
+          "role": 'admin',
           'new.role.name': 'farmer',
         },
       };
@@ -743,15 +743,11 @@ describe('Clients', function() {
         const {id} = this.currentClient;
 
         const availableRoles = await this.kcAdminClient.clients.listAvailableRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
 
         await this.kcAdminClient.clients.addRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
           availableRoles,
         );
 
@@ -760,9 +756,7 @@ describe('Clients', function() {
         });
 
         expect(roles).to.be.ok;
-        expect(roles.sort((a, b) => (a.name < b.name ? -1 : 1))).to.be.eql(
-          availableRoles.sort((a, b) => (a.name < b.name ? -1 : 1)),
-        );
+        expect(roles).to.deep.members(availableRoles);
       });
 
       it('list scope mappings', async () => {
@@ -776,9 +770,7 @@ describe('Clients', function() {
       it('list available scope mappings', async () => {
         const {id} = this.currentClient;
         const roles = await this.kcAdminClient.clients.listAvailableRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
         expect(roles).to.be.ok;
       });
@@ -786,9 +778,7 @@ describe('Clients', function() {
       it('list composite scope mappings', async () => {
         const {id} = this.currentClient;
         const roles = await this.kcAdminClient.clients.listCompositeRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
         expect(roles).to.be.ok;
       });
@@ -797,22 +787,16 @@ describe('Clients', function() {
         const {id} = this.currentClient;
 
         const rolesBefore = await this.kcAdminClient.clients.listRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
 
         await this.kcAdminClient.clients.delRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
           rolesBefore,
         );
 
         const rolesAfter = await this.kcAdminClient.clients.listRealmScopeMappings(
-          {
-            id,
-          },
+          {id},
         );
 
         expect(rolesAfter).to.be.ok;

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -438,7 +438,7 @@ describe('Clients', function() {
         protocol: 'openid-connect',
         protocolMapper: 'oidc-role-name-mapper',
         config: {
-          "role": 'admin',
+          role: 'admin',
           'new.role.name': 'farmer',
         },
       };

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -599,4 +599,225 @@ describe('Clients', function() {
       expect(mapper).not.to.be.ok;
     });
   });
+
+  describe('scope mappings', () => {
+    it('list client and realm scope mappings', async () => {
+      const {id} = this.currentClient;
+      const scopes = await this.kcAdminClient.clients.listScopeMappings({
+        id,
+      });
+      expect(scopes).to.be.ok;
+    });
+
+    describe('client', () => {
+      const dummyRoleName = 'clientScopeMappingsRole-dummy';
+
+      beforeEach(async () => {
+        const {id} = this.currentClient;
+        await this.kcAdminClient.clients.createRole({
+          id,
+          name: dummyRoleName,
+        });
+      });
+
+      afterEach(async () => {
+        try {
+          const {id} = this.currentClient;
+          await this.kcAdminClient.clients.delRole({
+            id,
+            roleName: dummyRoleName,
+          });
+        } catch (e) {
+          // ignore
+        }
+      });
+
+      it('add scope mappings', async () => {
+        const {id: clientUniqueId} = this.currentClient;
+
+        const availableRoles = await this.kcAdminClient.clients.listAvailableClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+        );
+
+        await this.kcAdminClient.clients.addClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+          availableRoles,
+        );
+
+        const roles = await this.kcAdminClient.clients.listClientScopeMappings({
+          id: clientUniqueId,
+          client: clientUniqueId,
+        });
+
+        expect(roles).to.be.ok;
+        expect(roles).to.be.eql(availableRoles);
+      });
+
+      it('list scope mappings', async () => {
+        const {id: clientUniqueId} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listClientScopeMappings({
+          id: clientUniqueId,
+          client: clientUniqueId,
+        });
+        expect(roles).to.be.ok;
+      });
+
+      it('list available scope mappings', async () => {
+        const {id: clientUniqueId} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listAvailableClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+        );
+        expect(roles).to.be.ok;
+      });
+
+      it('list composite scope mappings', async () => {
+        const {id: clientUniqueId} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listCompositeClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+        );
+        expect(roles).to.be.ok;
+      });
+
+      it('delete scope mappings', async () => {
+        const {id: clientUniqueId} = this.currentClient;
+
+        const rolesBefore = await this.kcAdminClient.clients.listClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+        );
+
+        await this.kcAdminClient.clients.delClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+          rolesBefore,
+        );
+
+        const rolesAfter = await this.kcAdminClient.clients.listClientScopeMappings(
+          {
+            id: clientUniqueId,
+            client: clientUniqueId,
+          },
+        );
+
+        expect(rolesAfter).to.be.ok;
+        expect(rolesAfter).to.eql([]);
+      });
+    });
+
+    describe('realm', () => {
+      const dummyRoleName = 'realmScopeMappingsRole-dummy';
+
+      beforeEach(async () => {
+        await this.kcAdminClient.roles.create({
+          name: dummyRoleName,
+        });
+      });
+
+      afterEach(async () => {
+        try {
+          await this.kcAdminClient.roles.delByName({
+            name: dummyRoleName,
+          });
+        } catch (e) {
+          // ignore
+        }
+      });
+
+      it('add scope mappings', async () => {
+        const {id} = this.currentClient;
+
+        const availableRoles = await this.kcAdminClient.clients.listAvailableRealmScopeMappings(
+          {
+            id,
+          },
+        );
+
+        await this.kcAdminClient.clients.addRealmScopeMappings(
+          {
+            id,
+          },
+          availableRoles,
+        );
+
+        const roles = await this.kcAdminClient.clients.listRealmScopeMappings({
+          id,
+        });
+
+        expect(roles).to.be.ok;
+        expect(roles.sort((a, b) => (a.name < b.name ? -1 : 1))).to.be.eql(
+          availableRoles.sort((a, b) => (a.name < b.name ? -1 : 1)),
+        );
+      });
+
+      it('list scope mappings', async () => {
+        const {id} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listRealmScopeMappings({
+          id,
+        });
+        expect(roles).to.be.ok;
+      });
+
+      it('list available scope mappings', async () => {
+        const {id} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listAvailableRealmScopeMappings(
+          {
+            id,
+          },
+        );
+        expect(roles).to.be.ok;
+      });
+
+      it('list composite scope mappings', async () => {
+        const {id} = this.currentClient;
+        const roles = await this.kcAdminClient.clients.listCompositeRealmScopeMappings(
+          {
+            id,
+          },
+        );
+        expect(roles).to.be.ok;
+      });
+
+      it('delete scope mappings', async () => {
+        const {id} = this.currentClient;
+
+        const rolesBefore = await this.kcAdminClient.clients.listRealmScopeMappings(
+          {
+            id,
+          },
+        );
+
+        await this.kcAdminClient.clients.delRealmScopeMappings(
+          {
+            id,
+          },
+          rolesBefore,
+        );
+
+        const rolesAfter = await this.kcAdminClient.clients.listRealmScopeMappings(
+          {
+            id,
+          },
+        );
+
+        expect(rolesAfter).to.be.ok;
+        expect(rolesAfter).to.eql([]);
+      });
+    });
+  });
 });

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -48,7 +48,7 @@ describe('Group user integration', function() {
     });
   });
 
-  it('should list user\'s group and expect empty', async () => {
+  it("should list user's group and expect empty", async () => {
     const groups = await this.kcAdminClient.users.listGroups({
       id: this.currentUser.id,
     });

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -392,7 +392,7 @@ describe('Users', function() {
       });
     });
 
-    it('should list user\'s federated identities and expect empty', async () => {
+    it("should list user's federated identities and expect empty", async () => {
       const federatedIdentities = await this.kcAdminClient.users.listFederatedIdentities(
         {
           id: this.currentUser.id,


### PR DESCRIPTION
Hey maintainers!

This PR adds support for client scopes, scope mappings and protocol mappers.
We need the endpoints to manage our keycloak instance via node.

Looking forward for your feedback!

Greetings!