### PR TITLE
Add sessions endpoints for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ Supported for [user federation](https://www.keycloak.org/docs/latest/server_admi
 - Update (`PUT /{realm}/components/{id}`)
 - Delete (`DELETE /{realm}/components/{id}`)
 
+### [Sessions for clients]()
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clients.spec.ts
+
+- List user sessions for a specific client (`GET /{realm}/clients/{id}/user-sessions`)
+- List offline sessions for a specific client (`GET /{realm}/clients/{id}/offline-sessions`)
+- Get user session count for a specific client (`GET /{realm}/clients/{id}/session-count`)
+- List offline session count for a specific client (`GET /{realm}/clients/{id}/offline-session-count`)
+
 ## Not yet supported
 
 - [Attack Detection](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_attack_detection_resource)

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -7,6 +7,7 @@ import CredentialRepresentation from '../defs/credentialRepresentation';
 import ClientScopeRepresentation from '../defs/clientScopeRepresentation';
 import ProtocolMapperRepresentation from '../defs/protocolMapperRepresentation';
 import MappingsRepresentation from '../defs/mappingsRepresentation';
+import UserSessionRepresentation from '../defs/userSessionRepresentation';
 
 export interface ClientQuery {
   clientId?: string;
@@ -368,6 +369,45 @@ export class Clients extends Resource<{realm?: string}> {
   >({
     method: 'DELETE',
     path: '/{id}/scope-mappings/realm',
+    urlParamKeys: ['id'],
+  });
+
+  /**
+   * Sessions
+   */
+  public listSessions = this.makeRequest<
+    {id: string, first?: number; max?: number},
+    UserSessionRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/user-sessions',
+    urlParamKeys: ['id'],
+  });
+
+  public listOfflineSessions = this.makeRequest<
+    {id: string, first?: number; max?: number},
+    UserSessionRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/offline-sessions',
+    urlParamKeys: ['id'],
+  });
+
+  public getSessionCount = this.makeRequest<
+    {id: string},
+    { "count": number }
+  >({
+    method: 'GET',
+    path: '/{id}/session-count',
+    urlParamKeys: ['id'],
+  });
+
+  public getOfflineSessionCount = this.makeRequest<
+    {id: string},
+    { "count": number }
+  >({
+    method: 'GET',
+    path: '/{id}/offline-session-count',
     urlParamKeys: ['id'],
   });
 

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -804,4 +804,38 @@ describe('Clients', function() {
       });
     });
   });
+
+  describe('sessions', () => {
+    it('list clients user sessions', async () => {
+      const clientUniqueId = this.currentClient.id;
+      const userSessions = await this.kcAdminClient.clients.listSessions({
+        id: clientUniqueId,
+      });
+      expect(userSessions).to.be.ok;
+    });
+
+    it('list clients offline user sessions', async () => {
+      const clientUniqueId = this.currentClient.id;
+      const userSessions = await this.kcAdminClient.clients.listOfflineSessions({
+        id: clientUniqueId,
+      });
+      expect(userSessions).to.be.ok;
+    });
+
+    it('list clients user session count', async () => {
+      const clientUniqueId = this.currentClient.id;
+      const userSessions = await this.kcAdminClient.clients.getSessionCount({
+        id: clientUniqueId,
+      });
+      expect(userSessions).to.be.ok;
+    });
+
+    it('list clients offline user session count', async () => {
+      const clientUniqueId = this.currentClient.id;
+      const userSessions = await this.kcAdminClient.clients.getOfflineSessionCount({
+        id: clientUniqueId,
+      });
+      expect(userSessions).to.be.ok;
+    });
+  });
 });


### PR DESCRIPTION
@gerdsander has recently added support for user sessions from a user perspective. For our purposes we need the user sessions belonging to clients instead. I've created a working version for the following endpoints:

/{realm}/clients/{id}/user-sessions
/{realm}/clients/{id}/offline-sessions
/{realm}/clients/{id}/session-count
/{realm}/clients/{id}/offline-session-count