### PR TITLE
Permissions group

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,25 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Raise required action’s priority (`POST /{realm}/authentication/required-actions/{alias}/raise-priority`)
 - Get unregistered required actions Returns a list of unregistered required actions. (`GET /{realm}/authentication/unregistered-required-actions`)
 
+### [Authorization: Permission](https://www.keycloak.org/docs/8.0/authorization_services/#_overview)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clients.spec.ts
+
+- Create permission (`POST /{realm}/clients/{id}/authz/resource-server/permission/{type}`)
+- Get permission (`GET /{realm}/clients/{id}/authz/resource-server/permission/{type}/{permissionId}`)
+- Update permission (`PUT /{realm}/clients/{id}/authz/resource-server/permission/{type}/{permissionId}`)
+- Delete permission (`DELETE /{realm}/clients/{id}/authz/resource-server/permission/{type}/{permissionId}`)
+
+### [Authorization: Policy](https://www.keycloak.org/docs/8.0/authorization_services/#_overview)
+
+Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/clients.spec.ts
+
+- Create policy (`POST /{realm}/clients/{id}/authz/resource-server/policy/{type}`)
+- Get policy (`GET /{realm}/clients/{id}/authz/resource-server/policy/{type}/{policyId}`)
+- Get policy by name (`GET /{realm}/clients/{id}/authz/resource-server/policy/search`)
+- Update policy (`PUT /{realm}/clients/{id}/authz/resource-server/policy/{type}/{policyId}`)
+- Delete policy (`DELETE /{realm}/clients/{id}/authz/resource-server/policy/{policyId}`)
+
 ## Not yet supported
 
 - [Attack Detection](https://www.keycloak.org/docs-api/4.1/rest-api/index.html#_attack_detection_resource)

--- a/src/defs/managementPermissionReference.ts
+++ b/src/defs/managementPermissionReference.ts
@@ -1,5 +1,5 @@
 export interface ManagementPermissionReference {
-    enabled: boolean;
-    ressource: string;
-    scopePermissions: Record<string, string>;
+    enabled?: boolean;
+    resource?: string;
+    scopePermissions?: Record<string, string>;
 }

--- a/src/defs/managementPermissionReference.ts
+++ b/src/defs/managementPermissionReference.ts
@@ -1,0 +1,5 @@
+export interface ManagementPermissionReference {
+    enabled: boolean;
+    ressource: string;
+    scopePermissions: Record<string, string>;
+}

--- a/src/defs/policyRepresentation.ts
+++ b/src/defs/policyRepresentation.ts
@@ -25,4 +25,5 @@ export default interface PolicyRepresentation {
   resources?: string[];
   scopes?: string[];
   type?: string;
+  users?: string[];
 }

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -430,9 +430,10 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id', 'type', 'policyId'],
   });
 
-  public createPolicy = this.makeRequest<
+  public createPolicy = this.makeUpdateRequest<
+    {id: string, type: string},
     PolicyRepresentation,
-    {id: string; type: string}
+    PolicyRepresentation
   >({
     method: 'POST',
     path: '/{id}/authz/resource-server/policy/{type}',
@@ -466,7 +467,7 @@ export class Clients extends Resource<{realm?: string}> {
       await this.updatePolicy({id: payload.id, policyId: policyFound.id, type: payload.policy.type}, payload.policy);
       return this.findByName({id: payload.id, name: payload.policyName});
     } else {
-      await this.createPolicy({...payload.policy, id: payload.id});
+      return this.createPolicy({id: payload.id, type: payload.policy.type}, payload.policy);
     }
   }
 

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -420,24 +420,33 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id'],
   });
 
-  public updateUserPolicy = this.makeUpdateRequest<
-    {id: string, policyId: string},
+  public updatePolicy = this.makeUpdateRequest<
+    {id: string; type: string; policyId: string},
     PolicyRepresentation,
     void
   >({
     method: 'PUT',
-    path: '{id}/authz/resource-server/policy/user/{policyId}',
-    urlParamKeys: ['id', 'policyId'],
+    path: '/{id}/authz/resource-server/policy/{type}/{policyId}',
+    urlParamKeys: ['id', 'type', 'policyId'],
   });
 
-  public createUserPolicy = this.makeUpdateRequest<
-    {id: string},
+  public createPolicy = this.makeRequest<
     PolicyRepresentation,
-    PolicyRepresentation
+    {id: string; type: string}
   >({
     method: 'POST',
-    path: '{id}/authz/resource-server/policy/user',
-    urlParamKeys: ['id'],
+    path: '/{id}/authz/resource-server/policy/{type}',
+    urlParamKeys: ['id', 'type'],
+  });
+
+  public findOnePolicy = this.makeRequest<
+    {id: string; type: string; policyId: string},
+    void
+  >({
+    method: 'GET',
+    path: '/{id}/authz/resource-server/policy/{type}/{policyId}',
+    urlParamKeys: ['id', 'type', 'policyId'],
+    catchNotFound: true,
   });
 
   public delPolicy = this.makeRequest<
@@ -449,59 +458,68 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id', 'policyId'],
   });
 
-  public async createOrUpdateUserPolicy(
+  public async createOrUpdatePolicy(
     payload: {id: string; policyName: string; policy: PolicyRepresentation}
   ): Promise<PolicyRepresentation> {
-    const policyFound = await this.findByName(
-      {id: payload.id, name: payload.policyName}
-    );
+    const policyFound = await this.findByName({id: payload.id, name: payload.policyName});
     if (policyFound) {
-      await this.updateUserPolicy({id: payload.id, policyId: policyFound.id}, payload.policy);
+      await this.updatePolicy({id: payload.id, policyId: policyFound.id, type: payload.policy.type}, payload.policy);
       return this.findByName({id: payload.id, name: payload.policyName});
     } else {
-      return this.createUserPolicy({id: payload.id}, payload.policy);
+      await this.createPolicy({...payload.policy, id: payload.id});
     }
   }
 
   /**
    * Scopes
    */
-  public listScopes = this.makeRequest<
-    {id: string, ressourceName: string},
+  public listScopesByResource = this.makeRequest<
+    {id: string, resourceName: string},
     {id: string, name: string}[]
   >({
     method: 'GET',
-    path: '/{id}/authz/resource-server/resource/{ressourceName}/scopes',
-    urlParamKeys: ['id', 'ressourceName'],
+    path: '/{id}/authz/resource-server/resource/{resourceName}/scopes',
+    urlParamKeys: ['id', 'resourceName'],
   });
 
-  public updateScopePermission = this.makeUpdateRequest<
-    {id: string, scopePermissionId: string},
+  /**
+   * Permissions
+   */
+  public createPermission = this.makeRequest<
+    PolicyRepresentation,
+    {id: string; type: string}
+  >({
+    method: 'POST',
+    path: '/{id}/authz/resource-server/permission/{type}',
+    urlParamKeys: ['id', 'type'],
+  });
+
+  public updatePermission = this.makeUpdateRequest<
+    {id: string; type: string; permissionId: string},
     PolicyRepresentation,
     void
   >({
     method: 'PUT',
-    path: '/{id}/authz/resource-server/permission/scope/{scopePermissionId}',
-    urlParamKeys: ['id', 'scopePermissionId'],
+    path: '/{id}/authz/resource-server/permission/{type}/{permissionId}',
+    urlParamKeys: ['id', 'type', 'permissionId'],
   });
 
-  public delScopePermission = this.makeUpdateRequest<
-    {id: string, scopePermissionId: string},
-    PolicyRepresentation,
+  public delPermission = this.makeRequest<
+    {id: string; type: string; permissionId: string},
     void
   >({
     method: 'DELETE',
-    path: '/{id}/authz/resource-server/permission/scope/{scopePermissionId}',
-    urlParamKeys: ['id', 'scopePermissionId'],
+    path: '/{id}/authz/resource-server/permission/{type}/{permissionId}',
+    urlParamKeys: ['id', 'type', 'permissionId'],
   });
 
-  public findOneScopePermission = this.makeRequest<
-    {id: string, scopePermissionId: string},
+  public findOnePermission = this.makeRequest<
+    {id: string; type: string; permissionId: string},
     PolicyRepresentation
   >({
     method: 'GET',
-    path: '/{id}/authz/resource-server/permission/scope/{scopePermissionId}',
-    urlParamKeys: ['id', 'scopePermissionId'],
+    path: '/{id}/authz/resource-server/permission/{type}/{permissionId}',
+    urlParamKeys: ['id', 'type', 'permissionId'],
   });
 
   public getOfflineSessionCount = this.makeRequest<
@@ -510,19 +528,6 @@ export class Clients extends Resource<{realm?: string}> {
   >({
     method: 'GET',
     path: '/{id}/offline-session-count',
-    urlParamKeys: ['id'],
-  });
-
-  /**
-   * Authorization permissions
-   */
-  public updatePermission = this.makeUpdateRequest<
-    {id: string},
-    ManagementPermissionReference,
-    ManagementPermissionReference
-  >({
-    method: 'PUT',
-    path: '/{id}/management/permissions',
     urlParamKeys: ['id'],
   });
 

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -1,11 +1,10 @@
-import Resource from './resource';
-import GroupRepresentation from '../defs/groupRepresentation';
 import {KeycloakAdminClient} from '../client';
-import UserRepresentation from '../defs/userRepresentation';
+import GroupRepresentation from '../defs/groupRepresentation';
+import {ManagementPermissionReference} from '../defs/managementPermissionReference';
 import MappingsRepresentation from '../defs/mappingsRepresentation';
-import RoleRepresentation, {
-  RoleMappingPayload,
-} from '../defs/roleRepresentation';
+import RoleRepresentation, {RoleMappingPayload} from '../defs/roleRepresentation';
+import UserRepresentation from '../defs/userRepresentation';
+import Resource from './resource';
 
 export interface GroupQuery {
   first?: number;
@@ -173,6 +172,18 @@ export class Groups extends Resource<{realm?: string}> {
     method: 'GET',
     path: '/{id}/role-mappings/clients/{clientUniqueId}/available',
     urlParamKeys: ['id', 'clientUniqueId'],
+  });
+
+  /**
+   * Authorization permissions
+   */
+  public updatePermission = this.makeRequest<
+    {id: string, management: ManagementPermissionReference},
+    ManagementPermissionReference
+  >({
+    method: 'UPDATE',
+    path: '{id}/management/permissions',
+    urlParamKeys: ['id'],
   });
 
   constructor(client: KeycloakAdminClient) {

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -177,12 +177,22 @@ export class Groups extends Resource<{realm?: string}> {
   /**
    * Authorization permissions
    */
-  public updatePermission = this.makeRequest<
-    {id: string, management: ManagementPermissionReference},
+  public updatePermission = this.makeUpdateRequest<
+    {id: string},
+    ManagementPermissionReference,
     ManagementPermissionReference
   >({
-    method: 'UPDATE',
-    path: '{id}/management/permissions',
+    method: 'PUT',
+    path: '/{id}/management/permissions',
+    urlParamKeys: ['id'],
+  });
+
+  public listPermissions = this.makeRequest<
+    {id: string},
+    ManagementPermissionReference
+  >({
+    method: 'GET',
+    path: '/{id}/management/permissions',
     urlParamKeys: ['id'],
   });
 

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -119,13 +119,14 @@ describe('Group user integration', function () {
 
     it('list of users in policy management', async () => {
       const userPolicyData: PolicyRepresentation = {
+        id: this.managementClient.id,
         type: 'user',
         logic: Logic.POSITIVE,
         decisionStrategy: DecisionStrategy.UNANIMOUS,
         name: `policy.manager.${this.currentGroup.id}`,
         users: [this.currentUser.id],
       };
-      this.currentUserPolicy = await this.kcAdminClient.clients.createUserPolicy({id: this.managementClient.id}, userPolicyData)
+      this.currentUserPolicy = await this.kcAdminClient.clients.createPolicy(userPolicyData)
 
       expect(this.currentUserPolicy).to.include({
         type: 'user',
@@ -140,9 +141,9 @@ describe('Group user integration', function () {
 
       expect(permissions.scopePermissions).to.be.an('object');
 
-      const scopes = await this.kcAdminClient.clients.listScopes({
+      const scopes = await this.kcAdminClient.clients.listScopesByResource({
         id: this.managementClient.id,
-        ressourceName: permissions.resource,
+        resourceName: permissions.resource,
       });
 
       expect(scopes).to.have.length(5);
@@ -167,16 +168,18 @@ describe('Group user integration', function () {
         scopes: [roleId],
         policies: [userPolicy.id],
       };
-      await this.kcAdminClient.clients.updateScopePermission(
+      await this.kcAdminClient.clients.updatePermission(
         {
           id: this.managementClient.id,
-          scopePermissionId: permissions.scopePermissions.manage,
+          permissionId: permissions.scopePermissions.manage,
+          type: 'scope'
         },
         policyData,
       );
-      this.currentPolicy = await this.kcAdminClient.clients.findOneScopePermission({
+      this.currentPolicy = await this.kcAdminClient.clients.findOnePermission({
         id: this.managementClient.id,
-        scopePermissionId: permissions.scopePermissions.manage,
+        permissionId: permissions.scopePermissions.manage,
+        type: 'scope'
       })
       expect(this.currentPolicy).to.deep.include({
         id: permissions.scopePermissions.manage,

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -101,9 +101,8 @@ describe('Group user integration', function () {
   describe('authorization permissions', () => {
     before(async () => {
       const clients = await this.kcAdminClient.clients.find();
-      this.managementClient = clients.find(client => client.clientId === 'realm-management')
+      this.managementClient = clients.find(client => client.clientId === 'master-realm')
     });
-
     after(async () => {
       await this.kcAdminClient.clients.delPolicy({
         id: this.managementClient.id,

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -119,14 +119,13 @@ describe('Group user integration', function () {
 
     it('list of users in policy management', async () => {
       const userPolicyData: PolicyRepresentation = {
-        id: this.managementClient.id,
         type: 'user',
         logic: Logic.POSITIVE,
         decisionStrategy: DecisionStrategy.UNANIMOUS,
         name: `policy.manager.${this.currentGroup.id}`,
         users: [this.currentUser.id],
       };
-      this.currentUserPolicy = await this.kcAdminClient.clients.createPolicy(userPolicyData)
+      this.currentUserPolicy = await this.kcAdminClient.clients.createPolicy({id: this.managementClient.id, type: userPolicyData.type}, userPolicyData)
 
       expect(this.currentUserPolicy).to.include({
         type: 'user',


### PR DESCRIPTION
In addition to the pull request https://github.com/keycloak/keycloak-nodejs-admin-client/pull/46 we could add permissions in groups. I am containing duplicates compared to what has already been done in this pull request, but it was to make it work on my side.

- Enable permissions for a group
- User policy management
- Update scope permissions