### PR TITLE
Add optional TOTP attribute in auth payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ await kcAdminClient.auth({
   password: 'wwwy3y3',
   grantType: 'password',
   clientId: 'admin-cli',
+  totp: '123456', // optional Time-based One-time Password if OTP is required in authentication flow
 });
 
 // List all users

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -9,6 +9,7 @@ export interface Credentials {
   grantType: string;
   clientId: string;
   clientSecret?: string;
+  totp?: string;
 }
 
 export interface Settings {
@@ -43,6 +44,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
     password: credentials.password,
     grant_type: credentials.grantType,
     client_id: credentials.clientId,
+    totp: credentials.totp,
   });
   const config: AxiosRequestConfig = {
     ...settings.requestConfig,


### PR DESCRIPTION
Background:
This PR is to add the capability for authentication flows that has One-time password enabled.

Changes:
- `totp` (Time-based One-time Password) added to the authentication request payload
- this option is also mentioned in the readme

Reference:
- https://www.keycloak.org/docs/5.0/server_admin/#otp-policies