### PR TITLE
Update usage of open-id client in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ const keycloakIssuer = await Issuer.discover(
 
 const client = new keycloakIssuer.Client({
   client_id: 'admin-cli', // Same as `clientId` passed to client.auth()
+  token_endpoint_auth_method: 'none', // to send only client_id in the header
 });
 
 // Use the grant type 'password'


### PR DESCRIPTION
Add `token_endpoint_auth_method` option to open-id client as it is needed to send only client_id header (without client secret, since it is not provided here).