### PR TITLE
Adding types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "files": [
     "lib"
   ],
+  "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --force --format verbose \"src/**/*.ts\" \"test/*\"",


### PR DESCRIPTION
When working on a typescript project in Webstorm 2020.1 that uses this package as a dependency, typings are not visible to Webstorm. Adding `"types": "lib/index.d.ts"` to this library's `package.json` remedies this.

If there's a better way to solve this, please let me know.