### PR TITLE
fix(auth): avoid adding scope key to payload if not needed

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -46,7 +46,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
     grant_type: credentials.grantType,
     client_id: credentials.clientId,
     totp: credentials.totp,
-    scope: credentials.offlineToken ? 'offline_access' : '',
+    ...(credentials.offlineToken ? {scope: 'offline_access'} : {}),
   });
   const config: AxiosRequestConfig = {
     ...settings.requestConfig,


### PR DESCRIPTION
This is an attempt on fixing the bug reported on #99 

I found out that adding an empty `scope` key to the payload messed with the authorization call to get the token responding with:
```json
{
  "error": "invalid_scope",
  "error_description": "Invalid scopes: "
}
```
I didn't find that tests were working or being used at all so I didn't add any updates on it but by all means please feel free to point me in the right path to adding a proper test for this scenario.