### PR TITLE
Fixes tests for Keycloak 9+

### DIFF
--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -78,8 +78,17 @@ describe('Users', function () {
 
   it('count users with filter', async () => {
     const numUsers = await kcAdminClient.users.count({email: 'wwwy3y3@canner.io'});
-    // should be 1, but it seems it doesn't work issue: KEYCLOAK-16081
-    expect(numUsers).to.equal(2);
+
+    if (process.env.KEYCLOAK_VERSION
+        && (
+          process.env.KEYCLOAK_VERSION.startsWith("7.")
+          || process.env.KEYCLOAK_VERSION.startsWith("8.")
+        )) {
+      // should be 1, but it seems it doesn't work issue: KEYCLOAK-16081
+      expect(numUsers).to.equal(2);
+    } else {
+      expect(numUsers).to.equal(1);
+    }
   });
 
   it('get single users', async () => {


### PR DESCRIPTION
Apprently there is some issue for Keycloak 7 and 8 that is being accounted for in the tests. This isolates the adjustment to only 7 and 8, and lets test for 9+ run as intended.