### PR TITLE
Added methods for resources evaluation & authorization scope creation (Auth service)

### DIFF
--- a/src/defs/resourceEvaluation.ts
+++ b/src/defs/resourceEvaluation.ts
@@ -1,0 +1,13 @@
+import ResourceRepresentation from "./resourceRepresentation";
+
+export default interface ResourceEvaluation {
+  rolesIds?: string[];
+  userId: string;
+  resources?: ResourceRepresentation[];
+  entitlements: boolean;
+  context: {
+    attributes: {
+      [key: string]: string;
+    };
+  };
+}

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -10,6 +10,7 @@ import RoleRepresentation from '../defs/roleRepresentation';
 import UserRepresentation from '../defs/userRepresentation';
 import UserSessionRepresentation from '../defs/userSessionRepresentation';
 import Resource from './resource';
+import ResourceEvaluation from "../defs/resourceEvaluation";
 
 export interface ClientQuery {
   first?: number;
@@ -486,6 +487,15 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id', 'resourceId'],
   });
 
+  public evaluateResource = this.makeUpdateRequest<
+    { id: string },
+    ResourceEvaluation
+  >({
+    method: 'POST',
+    path: '{id}/authz/resource-server/policy/evaluate',
+    urlParamKeys: ['id'],
+  });
+
   /**
    * Policy
    */
@@ -583,6 +593,15 @@ export class Clients extends Resource<{realm?: string}> {
     method: 'GET',
     path: '/{id}/authz/resource-server/resource/{resourceName}/scopes',
     urlParamKeys: ['id', 'resourceName'],
+  });
+
+  public createAuthorizationScope = this.makeUpdateRequest<
+    {id: string},
+    {name: string; displayName?: string; iconUri?: string}
+  >({
+    method: 'POST',
+    path: '{id}/authz/resource-server/scope',
+    urlParamKeys: ['id'],
   });
 
   /**


### PR DESCRIPTION
Added more endpoints for Authorization Service :

- Create Authorization Scope:  `POST {id}/authz/resource-server/scope`
- Evaluate resource permission:  `POST {id}/authz/resource-server/policy/evaluate`

Create a new interface to handle evaluation parameters input: `ResourceEvaluation`