### PR TITLE
Added support for partial-export of realms

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Get the top-level representation of the realm (`GET /{realm}`)
 - Update the top-level information of the realm (`PUT /{realm}`)
 - Delete the realm (`DELETE /{realm}`)
+- Partial export of existing realm into a JSON file (`POST /{realm}/partial-export`)
 - Get users management permissions (`GET /{realm}/users-management-permissions`)
 - Enable users management permissions (`PUT /{realm}/users-management-permissions`)
 - Get events (`GET /{realm}/events`)
@@ -150,7 +151,9 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Send an email-verification email to the user An email contains a link the user can click to verify their email address. (`PUT /{realm}/users/{id}/send-verify-email`)
 
 ### User group-mapping
+
 Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/users.spec.ts#L178
+
 - Add user to group (`PUT /{id}/groups/{groupId}`)
 - List all user groups (`GET /{id}/groups`)
 - Count user groups (`GET /{id}/groups/count`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "keycloak-admin",
-  "version": "1.14.1",
+  "name": "@keycloak/keycloak-admin-client",
+  "version": "1.14.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/resources/realms.ts
+++ b/src/resources/realms.ts
@@ -46,6 +46,23 @@ export class Realms extends Resource {
     urlParamKeys: ['realm'],
   });
 
+  public export = this.makeRequest<
+    {
+      realm: string,
+      exportClients?: boolean,
+      exportGroupsAndRoles?: boolean
+    },
+    RealmRepresentation
+  >({
+    method: 'POST',
+    path: '/{realm}/partial-export',
+    urlParamKeys: ['realm'],
+    queryParamKeys: [
+      'exportClients',
+      'exportGroupsAndRoles'
+    ]
+  });
+
   /**
    * Get events Returns all events, or filters them based on URL query parameters listed here
    */

--- a/test/realms.spec.ts
+++ b/test/realms.spec.ts
@@ -63,6 +63,18 @@ describe('Realms', () => {
     });
   });
 
+  it('export a realm', async () => {
+    const realm = await kcAdminClient.realms.export({
+      realm: currentRealmName,
+      exportClients: true,
+      exportGroupsAndRoles: true,
+    });
+    expect(realm).to.include({
+      id: currentRealmId,
+      realm: currentRealmName,
+    });
+  });
+
   it('update a realm', async () => {
     await kcAdminClient.realms.update(
       {realm: currentRealmName},


### PR DESCRIPTION
The **_GET /{realm}_** route returns a limited set of data.  When trying to orchestrate Keycloak from a remote server using the API, it is sometimes necessary to get more data on a realm before taking an action.  The partial-export route (**_POST /{realm}/parital-export_**) available via the admin API in Keycloak returns this extra data (clients, groups, roles, etc).

Adding support for this route is simple as it is just an extension of the other routes available in the realms resource.

NOTE: README.md and unit tests were also updated, matching previous conventions on pull requests that added support for a new route.