### PR TITLE
Fix typedef for Component Representation

### DIFF
--- a/src/defs/componentRepresentation.ts
+++ b/src/defs/componentRepresentation.ts
@@ -9,5 +9,5 @@ export default interface ComponentRepresentation {
   providerType?: string;
   parentId?: string;
   subType?: string;
-  config?: {[index: string]: string};
+  config?: {[index: string]: string | string[]};
 }


### PR DESCRIPTION
Component Representation for Keycloak expects config parameters to be string arrays. This extends the typedef to allow for this.

Here is a copy / paste of a request to create a User Federation object:

```json
{
  "name": "ldap",
  "providerId": "ldap",
  "providerType": "org.keycloak.storage.UserStorageProvider",
  "parentId": "123d2a50-456c-7897-1011-121314152cd8",
  "config": {
    "enabled": [
      "true"
    ],
    "priority": [
      "0"
    ],
    "fullSyncPeriod": [
      "604800"
    ],
    "changedSyncPeriod": [
      "60"
    ],
    "cachePolicy": [
      "DEFAULT"
    ],
    "evictionDay": [],
    "evictionHour": [],
    "evictionMinute": [],
    "maxLifespan": [],
    "batchSizeForSync": [
      "1000"
    ],
    "editMode": [],
    "importEnabled": [
      "true"
    ],
    "syncRegistrations": [
      "false"
    ],
    "vendor": [
      "rhds"
    ],
    "usePasswordModifyExtendedOp": [],
    "usernameLDAPAttribute": [
      "uid"
    ],
    "rdnLDAPAttribute": [
      "uid"
    ],
    "uuidLDAPAttribute": [
      "ipaUniqueID"
    ],
    "userObjectClasses": [
      "inetOrgPerson, organizationalPerson"
    ],
    "connectionUrl": [
      "ldap://hostname"
    ],
    "usersDn": [
      "cn=users,cn=accounts,dc=example,dc=com"
    ],
    "authType": [
      "simple"
    ],
    "startTls": [],
    "bindDn": [
      "uid=admin,cn=users,cn=accounts,dc=example,dc=com"
    ],
    "bindCredential": [
      "password"
    ],
    "customUserSearchFilter": [],
    "searchScope": [
      "1"
    ],
    "validatePasswordPolicy": [
      "false"
    ],
    "trustEmail": [
      "false"
    ],
    "useTruststoreSpi": [
      "ldapsOnly"
    ],
    "connectionPooling": [
      "true"
    ],
    "connectionPoolingAuthentication": [],
    "connectionPoolingDebug": [],
    "connectionPoolingInitSize": [],
    "connectionPoolingMaxSize": [],
    "connectionPoolingPrefSize": [],
    "connectionPoolingProtocol": [],
    "connectionPoolingTimeout": [],
    "connectionTimeout": [],
    "readTimeout": [],
    "pagination": [
      "true"
    ],
    "allowKerberosAuthentication": [
      "false"
    ],
    "serverPrincipal": [],
    "keyTab": [],
    "kerberosRealm": [],
    "debug": [
      "false"
    ],
    "useKerberosForPasswordAuthentication": [
      "false"
    ]
  }
}
```