### PR TITLE
Allow searching users by custom attributes

### DIFF
--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -23,7 +23,7 @@ export interface UserQuery {
 }
 
 export class Users extends Resource<{realm?: string}> {
-  public find = this.makeRequest<UserQuery, UserRepresentation[]>({
+  public find = this.makeRequest<UserQuery & {[key: string]: string}, UserRepresentation[]>({
     method: 'GET',
   });
 

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -23,7 +23,7 @@ export interface UserQuery {
 }
 
 export class Users extends Resource<{realm?: string}> {
-  public find = this.makeRequest<UserQuery & {[key: string]: string}, UserRepresentation[]>({
+  public find = this.makeRequest<UserQuery & {[key: string]: string | number}, UserRepresentation[]>({
     method: 'GET',
   });
 

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -33,6 +33,9 @@ describe('Users', function () {
       // enabled required to be true in order to send actions email
       emailVerified: true,
       enabled: true,
+      attributes: {
+        key: 'value',
+      },
     });
 
     expect(user.id).to.be.ok;
@@ -88,6 +91,17 @@ describe('Users', function () {
       expect(numUsers).to.equal(2);
     } else {
       expect(numUsers).to.equal(1);
+    }
+  });
+
+  it('find users by custom attributes', async function() {
+    // Searching by attributes is only available from Keycloak > 15
+    if (process.env.KEYCLOAK_VERSION && process.env.KEYCLOAK_VERSION.startsWith('15.')) {
+      const users = await kcAdminClient.users.find({key: 'value'});
+      expect(users.length).to.be.equal(1);
+      expect(users[0]).to.be.deep.include(currentUser);
+    } else {
+      this.skip();
     }
   });
 


### PR DESCRIPTION
This will allow searching users by custom attributes. The attributes will be set as query parameters.

This depends on https://github.com/keycloak/keycloak/pull/8329