### PR TITLE
src: add repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/keycloak/keycloak-nodejs-admin-client.git"
+    "url": "https://github.com/keycloak/keycloak-nodejs-admin-client.git"
   },
   "homepage": "https://www.keycloak.org/"
 }

--- a/package.json
+++ b/package.json
@@ -47,5 +47,10 @@
     "typescript": "^4.0.5"
   },
   "author": "wwwy3y3",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keycloak/keycloak-nodejs-admin-client.git"
+  },
+  "homepage": "http://keycloak.org"
 }

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "type": "git",
     "url": "git+https://github.com/keycloak/keycloak-nodejs-admin-client.git"
   },
-  "homepage": "http://keycloak.org"
+  "homepage": "https://www.keycloak.org/"
 }


### PR DESCRIPTION
This is commonly expected and needed for tooling that
more deeply inpects/analzes npm packages.

Signed-off-by: Michael Dawson <mdawson@devrus.com>