### PR TITLE
Add endpoints to get scopes and resources associated to a given permission

### DIFF
--- a/src/defs/resourceRepresentation.ts
+++ b/src/defs/resourceRepresentation.ts
@@ -4,7 +4,7 @@
 import ScopeRepresentation from './scopeRepresentation';
 
 export default interface ResourceRepresentation {
-  id?: string;
+  _id?: string;
   attributes?: Record<string, any>;
   displayName?: string;
   icon_uri?: string;

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -597,7 +597,10 @@ export class Clients extends Resource<{realm?: string}> {
   /**
    * Scopes
    */
-  public listAllScopes = this.makeRequest<{id: string}>({
+  public listAllScopes = this.makeRequest<
+    {id: string},
+    {id: string; name: string}[]
+  >({
     method: 'GET',
     path: '/{id}/authz/resource-server/scope',
     urlParamKeys: ['id'],
@@ -673,7 +676,7 @@ export class Clients extends Resource<{realm?: string}> {
 
   public getAssociatedScopes = this.makeRequest<
     {id: string; permissionId: string},
-    {id: string; name: string}
+    {id: string; name: string}[]
   >({
     method: 'GET',
     path: '/{id}/authz/resource-server/policy/{permissionId}/scopes',
@@ -682,7 +685,7 @@ export class Clients extends Resource<{realm?: string}> {
 
   public getAssociatedResources = this.makeRequest<
     {id: string; permissionId: string},
-    {_id: string; name: string}
+    {_id: string; name: string}[]
   >({
     method: 'GET',
     path: '/{id}/authz/resource-server/policy/{permissionId}/resources',

--- a/src/resources/clients.ts
+++ b/src/resources/clients.ts
@@ -671,6 +671,24 @@ export class Clients extends Resource<{realm?: string}> {
     urlParamKeys: ['id', 'type', 'permissionId'],
   });
 
+  public getAssociatedScopes = this.makeRequest<
+    {id: string; permissionId: string},
+    {id: string; name: string}
+  >({
+    method: 'GET',
+    path: '/{id}/authz/resource-server/policy/{permissionId}/scopes',
+    urlParamKeys: ['id', 'permissionId'],
+  });
+
+  public getAssociatedResources = this.makeRequest<
+    {id: string; permissionId: string},
+    {_id: string; name: string}
+  >({
+    method: 'GET',
+    path: '/{id}/authz/resource-server/policy/{permissionId}/resources',
+    urlParamKeys: ['id', 'permissionId'],
+  });
+
   public getOfflineSessionCount = this.makeRequest<
     {id: string},
     {count: number}

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -985,6 +985,23 @@ describe('Clients', () => {
         username,
       });
     });
+
+    after('delete test user', async () => {
+      await kcAdminClient.users.del({
+        id: user.id,
+      });
+    });
+
+    after('disable authorization services', async () => {
+      await kcAdminClient.clients.update(
+        { id: currentClient.id },
+        { 
+          clientId: currentClient.clientId,
+          authorizationServicesEnabled: false,
+          serviceAccountsEnabled: false,
+        }
+      );
+    });
     
     it('create authorization scopes', async () => {
       scopes = (await Promise.all(resourceConfig.scopeNames.map(async (name) => {

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -9,7 +9,7 @@ import ClientScopeRepresentation from '../src/defs/clientScopeRepresentation';
 import ScopeRepresentation from '../src/defs/scopeRepresentation';
 import ResourceRepresentation from '../src/defs/resourceRepresentation';
 import UserRepresentation from '../src/defs/userRepresentation';
-import PolicyRepresentation, { Logic } from '../src/defs/policyRepresentation';
+import PolicyRepresentation, {Logic} from '../src/defs/policyRepresentation';
 const expect = chai.expect;
 
 describe('Clients', () => {
@@ -894,15 +894,25 @@ describe('Clients', () => {
   describe('nodes', () => {
     const host = '127.0.0.1';
     it('register a node manually', async () => {
-      await kcAdminClient.clients.addClusterNode({id: currentClient.id, node: host});
-      const client = await kcAdminClient.clients.findOne({id: currentClient.id});
+      await kcAdminClient.clients.addClusterNode({
+        id: currentClient.id,
+        node: host,
+      });
+      const client = await kcAdminClient.clients.findOne({
+        id: currentClient.id,
+      });
 
       expect(Object.keys(client.registeredNodes)).to.be.eql([host]);
     });
 
     it('remove registered host', async () => {
-      await kcAdminClient.clients.deleteClusterNode({id: currentClient.id, node: host});
-      const client = await kcAdminClient.clients.findOne({id: currentClient.id});
+      await kcAdminClient.clients.deleteClusterNode({
+        id: currentClient.id,
+        node: host,
+      });
+      const client = await kcAdminClient.clients.findOne({
+        id: currentClient.id,
+      });
 
       expect(client.registeredNodes).to.be.undefined;
     });
@@ -920,23 +930,35 @@ describe('Clients', () => {
     const attr = 'jwt.credential';
 
     it('generate and download keys', async () => {
-      const result = await kcAdminClient.clients.generateAndDownloadKey({id: currentClient.id, attr}, keystoreConfig);
+      const result = await kcAdminClient.clients.generateAndDownloadKey(
+        {id: currentClient.id, attr},
+        keystoreConfig,
+      );
 
       expect(result).to.be.ok;
     });
 
     it('generate key and updated info', async () => {
-      const certificate = await kcAdminClient.clients.generateKey({id: currentClient.id, attr});
+      const certificate = await kcAdminClient.clients.generateKey({
+        id: currentClient.id,
+        attr,
+      });
 
       expect(certificate).to.be.ok;
       expect(certificate.certificate).to.be.ok;
 
-      const info = await kcAdminClient.clients.getKeyInfo({id: currentClient.id, attr});
+      const info = await kcAdminClient.clients.getKeyInfo({
+        id: currentClient.id,
+        attr,
+      });
       expect(info).to.be.eql(certificate);
     });
 
     it('download key', async () => {
-      const result = await kcAdminClient.clients.downloadKey({id: currentClient.id, attr}, keystoreConfig);
+      const result = await kcAdminClient.clients.downloadKey(
+        {id: currentClient.id, attr},
+        keystoreConfig,
+      );
 
       expect(result).to.be.ok;
     });
@@ -946,11 +968,7 @@ describe('Clients', () => {
     const resourceConfig = {
       name: 'testResourceName',
       type: 'testResourceType',
-      scopeNames: [
-        'testScopeA',
-        'testScopeB',
-        'testScopeC',
-      ],
+      scopeNames: ['testScopeA', 'testScopeB', 'testScopeC'],
     };
     const policyConfig = {
       name: 'testPolicyName',
@@ -970,12 +988,12 @@ describe('Clients', () => {
 
     before('enable authorization services', async () => {
       await kcAdminClient.clients.update(
-        { id: currentClient.id },
-        { 
+        {id: currentClient.id},
+        {
           clientId: currentClient.clientId,
           authorizationServicesEnabled: true,
           serviceAccountsEnabled: true,
-        }
+        },
       );
     });
 
@@ -994,99 +1012,117 @@ describe('Clients', () => {
 
     after('disable authorization services', async () => {
       await kcAdminClient.clients.update(
-        { id: currentClient.id },
-        { 
+        {id: currentClient.id},
+        {
           clientId: currentClient.clientId,
           authorizationServicesEnabled: false,
           serviceAccountsEnabled: false,
-        }
+        },
       );
     });
-    
+
     it('create authorization scopes', async () => {
-      scopes = (await Promise.all(resourceConfig.scopeNames.map(async (name) => {
-        const result = await kcAdminClient.clients.createAuthorizationScope({ id: currentClient.id }, {
-          name,
-        })
-        expect(result).to.be.ok;
-        return result;
-      }))).sort((a, b) => a.name < b.name ? -1 : 1);
+      scopes = (
+        await Promise.all(
+          resourceConfig.scopeNames.map(async (name) => {
+            const result = await kcAdminClient.clients.createAuthorizationScope(
+              {id: currentClient.id},
+              {
+                name,
+              },
+            );
+            expect(result).to.be.ok;
+            return result;
+          }),
+        )
+      ).sort((a, b) => (a.name < b.name ? -1 : 1));
     });
 
     it('list all authorization scopes', async () => {
-      const result = await kcAdminClient.clients.listAllScopes({ id: currentClient.id });
-      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
+      const result = await kcAdminClient.clients.listAllScopes({
+        id: currentClient.id,
+      });
+      expect(result.sort((a, b) => (a.name < b.name ? -1 : 1))).to.deep.equal(
+        scopes,
+      );
     });
 
     it('create resource', async () => {
-      resource = await kcAdminClient.clients.createResource({ id: currentClient.id }, {
-        name: resourceConfig.name,
-        type: resourceConfig.type,
-        scopes: scopes,
-      });
+      resource = await kcAdminClient.clients.createResource(
+        {id: currentClient.id},
+        {
+          name: resourceConfig.name,
+          type: resourceConfig.type,
+          scopes,
+        },
+      );
       expect(resource).to.be.ok;
     });
 
     it('list scopes by resource', async () => {
-      // @ts-ignore
-      const result = await kcAdminClient.clients.listScopesByResource({ id: currentClient.id, resourceName: resource._id });
-      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
+      const result = await kcAdminClient.clients.listScopesByResource({
+        id: currentClient.id,
+        resourceName: resource._id,
+      });
+      expect(result.sort((a, b) => (a.name < b.name ? -1 : 1))).to.deep.equal(
+        scopes,
+      );
     });
 
     it('list resources', async () => {
-      const result = await kcAdminClient.clients.listResources({ id: currentClient.id });
+      const result = await kcAdminClient.clients.listResources({
+        id: currentClient.id,
+      });
       expect(result).to.deep.include(resource);
     });
 
     it('update resource', async () => {
-      const result = await kcAdminClient.clients.updateResource(
-        { 
-          id: currentClient.id, 
-          // @ts-ignore
-          resourceId: resource._id 
+      await kcAdminClient.clients.updateResource(
+        {
+          id: currentClient.id,
+          resourceId: resource._id,
         },
         {
           name: 'foo',
         },
       );
-      // updateResource does not return the updated resource, so we would have to fetch the resource again 
+      // updateResource does not return the updated resource, so we would have to fetch the resource again
       // to check. However, the endpoint is not implemented (yet?).
-      //expect(result).to.deep.equal({ ...resource, name: 'foo' });
+      // expect(result).to.deep.equal({ ...resource, name: 'foo' });
       // Change name back to original value
-      const result2 = await kcAdminClient.clients.updateResource(
-        { 
-          id: currentClient.id, 
-          // @ts-ignore
-          resourceId: resource._id 
+      await kcAdminClient.clients.updateResource(
+        {
+          id: currentClient.id,
+          resourceId: resource._id,
         },
         {
           name: resourceConfig.name,
         },
       );
-      //expect(result2).to.deep.equal(resource);
+      // expect(result2).to.deep.equal(resource);
     });
 
     it('create policy', async () => {
       policy = await kcAdminClient.clients.createPolicy(
-        { 
-          id: currentClient.id, 
-          type: policyConfig.type 
-        }, 
+        {
+          id: currentClient.id,
+          type: policyConfig.type,
+        },
         {
           name: policyConfig.name,
           logic: policyConfig.logic,
           users: [user.id],
-        }
+        },
       );
       expect(policy).to.be.ok;
     });
 
     it('create permission', async () => {
       permission = await kcAdminClient.clients.createPermission(
-        { 
-          id: currentClient.id, 
-          type: 'scope' 
-        }, 
+        {
+          id: currentClient.id,
+          type: 'scope',
+        },
         {
           name: permissionConfig.name,
           logic: permissionConfig.logic,
@@ -1094,34 +1130,31 @@ describe('Clients', () => {
           resources: [resource._id],
           policies: [policy.id],
           scopes: scopes.map((scope) => scope.id),
-        }
+        },
       );
       expect(permission).to.be.ok;
     });
 
     it('get associated scopes for permission', async () => {
-      const result = await kcAdminClient.clients.getAssociatedScopes(
-        { 
-          id: currentClient.id, 
-          permissionId: permission.id,
-        },
+      const result = await kcAdminClient.clients.getAssociatedScopes({
+        id: currentClient.id,
+        permissionId: permission.id,
+      });
+      expect(result.sort((a, b) => (a.name < b.name ? -1 : 1))).to.deep.equal(
+        scopes,
       );
-      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
     });
 
     it('get associated resources for permission', async () => {
-      const result = await kcAdminClient.clients.getAssociatedResources(
-        { 
-          id: currentClient.id, 
-          permissionId: permission.id,
-        },
-      );
+      const result = await kcAdminClient.clients.getAssociatedResources({
+        id: currentClient.id,
+        permissionId: permission.id,
+      });
       expect(result).to.deep.equal([
-        { 
-          // @ts-ignore
+        {
           _id: resource._id,
           name: resource.name,
-        }
+        },
       ]);
     });
   });

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -6,6 +6,10 @@ import faker from 'faker';
 import ClientRepresentation from '../src/defs/clientRepresentation';
 import ProtocolMapperRepresentation from '../src/defs/protocolMapperRepresentation';
 import ClientScopeRepresentation from '../src/defs/clientScopeRepresentation';
+import ScopeRepresentation from '../src/defs/scopeRepresentation';
+import ResourceRepresentation from '../src/defs/resourceRepresentation';
+import UserRepresentation from '../src/defs/userRepresentation';
+import PolicyRepresentation, { Logic } from '../src/defs/policyRepresentation';
 const expect = chai.expect;
 
 describe('Clients', () => {
@@ -935,6 +939,173 @@ describe('Clients', () => {
       const result = await kcAdminClient.clients.downloadKey({id: currentClient.id, attr}, keystoreConfig);
 
       expect(result).to.be.ok;
+    });
+  });
+
+  describe('authorization', async () => {
+    const resourceConfig = {
+      name: 'testResourceName',
+      type: 'testResourceType',
+      scopeNames: [
+        'testScopeA',
+        'testScopeB',
+        'testScopeC',
+      ],
+    };
+    const policyConfig = {
+      name: 'testPolicyName',
+      type: 'user',
+      logic: Logic.POSITIVE,
+    };
+    const permissionConfig = {
+      name: 'testPermissionName',
+      type: 'scope',
+      logic: Logic.POSITIVE,
+    };
+    let scopes: ScopeRepresentation[];
+    let resource: ResourceRepresentation;
+    let policy: PolicyRepresentation;
+    let permission: PolicyRepresentation;
+    let user: UserRepresentation;
+
+    before('enable authorization services', async () => {
+      await kcAdminClient.clients.update(
+        { id: currentClient.id },
+        { 
+          clientId: currentClient.clientId,
+          authorizationServicesEnabled: true,
+          serviceAccountsEnabled: true,
+        }
+      );
+    });
+
+    before('create test user', async () => {
+      const username = faker.internet.userName();
+      user = await kcAdminClient.users.create({
+        username,
+      });
+    });
+    
+    it('create authorization scopes', async () => {
+      scopes = (await Promise.all(resourceConfig.scopeNames.map(async (name) => {
+        const result = await kcAdminClient.clients.createAuthorizationScope({ id: currentClient.id }, {
+          name,
+        })
+        expect(result).to.be.ok;
+        return result;
+      }))).sort((a, b) => a.name < b.name ? -1 : 1);
+    });
+
+    it('list all authorization scopes', async () => {
+      const result = await kcAdminClient.clients.listAllScopes({ id: currentClient.id });
+      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
+    });
+
+    it('create resource', async () => {
+      resource = await kcAdminClient.clients.createResource({ id: currentClient.id }, {
+        name: resourceConfig.name,
+        type: resourceConfig.type,
+        scopes: scopes,
+      });
+      expect(resource).to.be.ok;
+    });
+
+    it('list scopes by resource', async () => {
+      // @ts-ignore
+      const result = await kcAdminClient.clients.listScopesByResource({ id: currentClient.id, resourceName: resource._id });
+      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
+    });
+
+    it('list resources', async () => {
+      const result = await kcAdminClient.clients.listResources({ id: currentClient.id });
+      expect(result).to.deep.include(resource);
+    });
+
+    it('update resource', async () => {
+      const result = await kcAdminClient.clients.updateResource(
+        { 
+          id: currentClient.id, 
+          // @ts-ignore
+          resourceId: resource._id 
+        },
+        {
+          name: 'foo',
+        },
+      );
+      // updateResource does not return the updated resource, so we would have to fetch the resource again 
+      // to check. However, the endpoint is not implemented (yet?).
+      //expect(result).to.deep.equal({ ...resource, name: 'foo' });
+      // Change name back to original value
+      const result2 = await kcAdminClient.clients.updateResource(
+        { 
+          id: currentClient.id, 
+          // @ts-ignore
+          resourceId: resource._id 
+        },
+        {
+          name: resourceConfig.name,
+        },
+      );
+      //expect(result2).to.deep.equal(resource);
+    });
+
+    it('create policy', async () => {
+      policy = await kcAdminClient.clients.createPolicy(
+        { 
+          id: currentClient.id, 
+          type: policyConfig.type 
+        }, 
+        {
+          name: policyConfig.name,
+          logic: policyConfig.logic,
+          users: [user.id],
+        }
+      );
+      expect(policy).to.be.ok;
+    });
+
+    it('create permission', async () => {
+      permission = await kcAdminClient.clients.createPermission(
+        { 
+          id: currentClient.id, 
+          type: 'scope' 
+        }, 
+        {
+          name: permissionConfig.name,
+          logic: permissionConfig.logic,
+          // @ts-ignore
+          resources: [resource._id],
+          policies: [policy.id],
+          scopes: scopes.map((scope) => scope.id),
+        }
+      );
+      expect(permission).to.be.ok;
+    });
+
+    it('get associated scopes for permission', async () => {
+      const result = await kcAdminClient.clients.getAssociatedScopes(
+        { 
+          id: currentClient.id, 
+          permissionId: permission.id,
+        },
+      );
+      expect(result.sort((a, b) => a.name < b.name ? -1 : 1)).to.deep.equal(scopes);
+    });
+
+    it('get associated resources for permission', async () => {
+      const result = await kcAdminClient.clients.getAssociatedResources(
+        { 
+          id: currentClient.id, 
+          permissionId: permission.id,
+        },
+      );
+      expect(result).to.deep.equal([
+        { 
+          // @ts-ignore
+          _id: resource._id,
+          name: resource.name,
+        }
+      ]);
     });
   });
 });


### PR DESCRIPTION
Similar to what was described in #101, I was trying to obtain the list of scopes associated with a scope-based permission. However, the endpoint `<client-id>/authz/resource-server/permission/scope/<permission-id>` only returns objects like this (I am running keycloak 11.0.2):
```
{
  decisionStrategy: ...,
  id: ...,
  logic: ...,
  name: ...,
  type: ...
}
```

Since the keycloak web UI uses the endpoints `<client-id>/authz/resource-server/policy/<permission-id>/scopes` and `<client-id>/authz/resource-server/policy/<permission-id>/resources` to fetch and display the scopes and resources associated with a permission, I figured it would be a good idea to add them to the admin client.