### PR TITLE
Add support for getCredentials and deleteCredential

### DIFF
--- a/src/defs/credentialRepresentation.ts
+++ b/src/defs/credentialRepresentation.ts
@@ -3,17 +3,13 @@
  */
 
 export default interface CredentialRepresentation {
-  algorithm?: string;
-  config?: Record<string, any>;
-  counter?: number;
   createdDate?: number;
-  device?: string;
-  digits?: number;
-  hashIterations?: number;
-  hashedSaltedValue?: string;
-  period?: number;
-  salt?: string;
+  credentialData?: string;
+  id?: string;
+  priority?: number;
+  secretData?: string;
   temporary?: boolean;
   type?: string;
+  userLabel?: string;
   value?: string;
 }

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -299,6 +299,30 @@ export class Users extends Resource<{realm?: string}> {
   });
 
   /**
+   * get user credentials
+   */
+  public getCredentials = this.makeRequest<
+    {id: string},
+    CredentialRepresentation[]
+  >({
+    method: 'GET',
+    path: '/{id}/credentials',
+    urlParamKeys: ['id']
+  });
+
+  /**
+   * delete user credentials
+   */
+  public deleteCredential = this.makeRequest<
+    {id: string; credentialId: string},
+    void
+  >({
+    method: 'DELETE',
+    path: '/{id}/credentials/{credentialId}',
+    urlParamKeys: ['id', 'credentialId']
+  });
+
+  /**
    * send verify email
    */
   public sendVerifyEmail = this.makeRequest<

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -142,8 +142,53 @@ describe('Users', function () {
    */
 
   it('should reset user password', async () => {
-    // todo: find a way to validate the reset-password result
     const userId = currentUser.id;
+    await kcAdminClient.users.resetPassword({
+      id: userId!,
+      credential: {
+        temporary: false,
+        type: 'password',
+        value: 'test',
+      },
+    });
+  });
+
+  /**
+   * get user credentials
+   */
+  it('get user credentials', async () => {
+    const userId = currentUser.id;
+    const credentials = await kcAdminClient.users.getCredentials({
+      id: userId!,
+    });
+
+    expect(credentials.map(c => c.type)).to.include('password')
+  });
+
+  /**
+   * delete user credentials
+   */
+  it('delete user credentials', async () => {
+    const userId = currentUser.id;
+    const credentials = await kcAdminClient.users.getCredentials({
+      id: userId!,
+    });
+
+    expect(credentials.map(c => c.type)).to.include('password')
+
+    const credential = credentials[0];
+    await kcAdminClient.users.deleteCredential({
+      id: userId!,
+      credentialId: credential.id!,
+    });
+
+    const credentialsAfterDelete = await kcAdminClient.users.getCredentials({
+      id: userId!,
+    });
+
+    expect(credentialsAfterDelete).to.not.deep.include(credential);
+
+    // Add deleted password back
     await kcAdminClient.users.resetPassword({
       id: userId!,
       credential: {


### PR DESCRIPTION
As a substitute for `removeTotp` REST API support, we have added support for `getCredentials` and `deleteCredential` methods.
The `getCredentials` method returns a `CredentialRepresentation` array and `deleteCredential` removes a credential.

Update `CredentialRepresentation` as prerequisite.

We have added tests for the two methods. `getCredentials` can also be used to validate the `resetPassword` method.