### PR TITLE
Issue-295 adding briefRepresentation support

### DIFF
--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -211,7 +211,7 @@ export class Users extends Resource<{realm?: string}> {
    * Group
    */
 
-  public listGroups = this.makeRequest<{id: string}, GroupRepresentation[]>({
+  public listGroups = this.makeRequest<{id: string, briefRepresentation?: boolean}, GroupRepresentation[]>({
     method: 'GET',
     path: '/{id}/groups',
     urlParamKeys: ['id'],


### PR DESCRIPTION
Fix for Issue-295.
Adding `briefRepresentation` support for `users.listGroups` to fetch group attributes when listing user groups.

