### PR TITLE
add first and max params to getRealmLocalizationTexts

### DIFF
--- a/src/resources/realms.ts
+++ b/src/resources/realms.ts
@@ -292,7 +292,7 @@ export class Realms extends Resource {
   });
 
   public getRealmLocalizationTexts = this.makeRequest<
-    {realm: string; selectedLocale: string},
+    {realm: string; selectedLocale: string; first?: number; max?: number},
     Record<string, string>
   >({
     method: 'GET',


### PR DESCRIPTION
Instead of spreading `params` over the arguments of the API call you can inline them instead.

```suggestion
      let result = await adminClient.realms.getRealmLocalizationTexts({
        first,
        max,
```

This will however cause compilation issues as the admin client does not know about `first` and `max`, so you will have to add them to the type there.

_Originally posted by @jonkoops in https://github.com/keycloak/keycloak-admin-ui/pull/1663#discussion_r766615389_