### PR TITLE
User credential position

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Set up a temporary password for the user User will have to reset the temporary password next time they log in. (`PUT /{realm}/users/{id}/reset-password`)
 - Send an email-verification email to the user An email contains a link the user can click to verify their email address. (`PUT /{realm}/users/{id}/send-verify-email`)
 - Update a credential label for a user (`PUT /{realm}/users/{id}/credentials/{credentialId}/userLabel`)
+- Move a credential to a position behind another credential (`POST /{realm}/users/{id}/credentials/{credentialId}/moveAfter/{newPreviousCredentialId}`)
+- Move a credential to a first position in the credentials list of the user (`PUT /{realm}/users/{id}/credentials/{credentialId}/moveToFirst`)
 
 ### User group-mapping
 

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -336,6 +336,33 @@ export class Users extends Resource<{realm?: string}> {
     headers: {'content-type': 'text/plain'},
   });
 
+  // Move a credential to a position behind another credential
+  public lowerCredentialPriority = this.makeRequest<
+    {
+      id: string;
+      credentialId: string;
+      newPreviousCredentialId: string;
+    },
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/credentials/{credentialId}/moveAfter/{newPreviousCredentialId}',
+    urlParamKeys: ['id', 'credentialId', 'newPreviousCredentialId'],
+  });
+
+  // Move a credential to a first position in the credentials list of the user
+  public raiseCredentialPriority = this.makeRequest<
+    {
+      id: string;
+      credentialId: string;
+    },
+    void
+  >({
+    method: 'POST',
+    path: '/{id}/credentials/{credentialId}/moveToFirst',
+    urlParamKeys: ['id', 'credentialId'],
+  });
+
   /**
    * send verify email
    */

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -337,7 +337,7 @@ export class Users extends Resource<{realm?: string}> {
   });
 
   // Move a credential to a position behind another credential
-  public lowerCredentialPriority = this.makeRequest<
+  public moveCredentialPositionDown = this.makeRequest<
     {
       id: string;
       credentialId: string;
@@ -351,7 +351,7 @@ export class Users extends Resource<{realm?: string}> {
   });
 
   // Move a credential to a first position in the credentials list of the user
-  public raiseCredentialPriority = this.makeRequest<
+  public moveCredentialPositionUp = this.makeRequest<
     {
       id: string;
       credentialId: string;


### PR DESCRIPTION
Added two endpoints as per https://www.keycloak.org/docs-api/15.0/rest-api/index.html

1. Move a credential to a position behind another credential -> POST /{realm}/users/{id}/credentials/{credentialId}/moveAfter/{newPreviousCredentialId}
2. Move a credential to a first position in the credentials list of the user -> POST /{realm}/users/{id}/credentials/{credentialId}/moveToFirst

Note: Didn't write tests as it is hard to add credentials other than that of type "password".
