### PR TITLE
Add exact to UserQuery

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,5 +25,3 @@ publish:
   stage: publish
   script:
     - npm publish
-  only:
-    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+include:
+  - template: Dependency-Scanning.gitlab-ci.yml
+  - template: License-Scanning.gitlab-ci.yml
+  - template: SAST.gitlab-ci.yml
+  - template: Secret-Detection.gitlab-ci.yml
+
+stages:
+  - build
+  - publish
+
+cache:
+  key: $CI_COMMIT_REF_SLUG
+  policy: pull-push
+  paths:
+    - .npm/
+
+build:
+  image: node:lts
+  stage: build
+  before_script:
+    - npm ci --cache .npm --prefer-offline
+    - npm install --cache .npm --prefer-offline
+  script:
+    - npm run build
+
+publish:
+  image: node:lts
+  before_script:
+    - npm config set '//gitlab.com/api/v4/packages/npm/:_authToken' "${CI_JOB_TOKEN}"
+    - npm config set '//gitlab.com/api/v4/projects/${CI_PROJECT_ID}/packages/npm/:_authToken' "${CI_JOB_TOKEN}"
+  stage: publish
+  script:
+    - npm publish
+  only:
+    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - build
   - publish
 
 cache:
@@ -8,15 +7,6 @@ cache:
   paths:
     - .npm/
 
-build:
-  image: node:lts
-  stage: build
-  before_script:
-    - npm ci --cache .npm --prefer-offline
-    - npm install --cache .npm --prefer-offline
-  script:
-    - npm run build
-
 publish:
   image: node:lts
   before_script:
@@ -24,4 +14,6 @@ publish:
     - npm config set '//gitlab.com/api/v4/projects/${CI_PROJECT_ID}/packages/npm/:_authToken' "${CI_JOB_TOKEN}"
   stage: publish
   script:
+    - npm ci --cache .npm --prefer-offline
+    - npm run build
     - npm publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,3 @@
-include:
-  - template: Dependency-Scanning.gitlab-ci.yml
-  - template: License-Scanning.gitlab-ci.yml
-  - template: SAST.gitlab-ci.yml
-  - template: Secret-Detection.gitlab-ci.yml
-
 stages:
   - build
   - publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@keycloak/keycloak-admin-client",
-  "version": "16.0.0-dev.63",
+  "name": "@eccoo-platform/keycloak-admin-client",
+  "version": "16.0.0-dev.63-equalcare",
   "description": "keycloak admin client",
   "main": "lib/index.js",
   "files": [
@@ -51,7 +51,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/keycloak/keycloak-nodejs-admin-client.git"
+    "url": "https://gitlab.com/eccoo-platform/common/keycloak-nodejs-admin-client.git"
   },
   "homepage": "https://www.keycloak.org/"
 }

--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -20,7 +20,8 @@ export interface UserQuery {
   max?: number;
   search?: string;
   username?: string;
-  [key: string]: string | number | undefined;
+  exact?: boolean;
+  [key: string]: string | number | undefined | boolean;
 }
 
 export class Users extends Resource<{realm?: string}> {


### PR DESCRIPTION
This is a small change to allow the `exact` parameter to be included when accessing the `GET /{realm}/users` endpoint.

I couldn't find any details about contributing guidelines. Please let me know if there's anything else you'd like to see here.