### PR TITLE
Add exact to UserQuery

### DIFF
--- a/src/resources/users.ts
+++ b/src/resources/users.ts
@@ -20,7 +20,8 @@ export interface UserQuery {
   max?: number;
   search?: string;
   username?: string;
-  [key: string]: string | number | undefined;
+  exact?: boolean;
+  [key: string]: string | number | undefined | boolean;
 }
 
 export class Users extends Resource<{realm?: string}> {


### PR DESCRIPTION
This is a small change to allow the exact parameter to be included when accessing the GET /{realm}/users endpoint.

I couldn't find any details about contributing guidelines. Please let me know if there's anything else you'd like to see here.

Supersedes #333 