### PR TITLE
Replace Lodash with the ESM compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^0.25.0",
         "camelize-ts": "^1.0.8",
         "keycloak-js": "^16.0.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "query-string": "^7.0.1",
         "url-join": "^4.0.0",
         "url-template": "^2.0.8"
@@ -22,7 +22,7 @@
         "@types/axios": "^0.14.0",
         "@types/chai": "^4.2.14",
         "@types/faker": "^6.6.9",
-        "@types/lodash": "^4.14.165",
+        "@types/lodash-es": "^4.17.5",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.1",
         "@types/url-join": "^4.0.0",
@@ -368,6 +368,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mocha": {
       "version": "9.1.0",
@@ -1527,7 +1536,13 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3122,6 +3137,15 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
+    "@types/lodash-es": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mocha": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
@@ -3985,7 +4009,13 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "axios": "^0.25.0",
     "camelize-ts": "^1.0.8",
     "keycloak-js": "^16.0.0",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "query-string": "^7.0.1",
     "url-join": "^4.0.0",
     "url-template": "^2.0.8"
@@ -33,7 +33,7 @@
     "@types/axios": "^0.14.0",
     "@types/chai": "^4.2.14",
     "@types/faker": "^6.6.9",
-    "@types/lodash": "^4.14.165",
+    "@types/lodash-es": "^4.17.5",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.1",
     "@types/url-join": "^4.0.0",

--- a/src/resources/agent.ts
+++ b/src/resources/agent.ts
@@ -2,7 +2,7 @@ import urlJoin from 'url-join';
 import template from 'url-template';
 import axios, {AxiosRequestConfig, AxiosRequestHeaders, Method} from 'axios';
 import querystring from 'query-string';
-import {pick, omit, isUndefined, last} from 'lodash';
+import {pick, omit, isUndefined, last} from 'lodash-es';
 import {KeycloakAdminClient} from '../client';
 
 // constants

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-unused-expression
 import * as chai from 'chai';
 import faker from '@faker-js/faker';
-import {omit, pick} from 'lodash';
+import {omit, pick} from 'lodash-es';
 import {KeycloakAdminClient} from '../src/client';
 import ClientRepresentation from '../src/defs/clientRepresentation';
 import GroupRepresentation from '../src/defs/groupRepresentation';

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -8,7 +8,7 @@ import RoleRepresentation from '../src/defs/roleRepresentation';
 import ClientRepresentation from '../src/defs/clientRepresentation';
 import {RequiredActionAlias} from '../src/defs/requiredActionProviderRepresentation';
 import FederatedIdentityRepresentation from '../src/defs/federatedIdentityRepresentation';
-import {omit} from 'lodash';
+import {omit} from 'lodash-es';
 import GroupRepresentation from '../src/defs/groupRepresentation';
 import {fail} from 'assert';
 


### PR DESCRIPTION
Replaces Lodash with it's ESM variant, which can reduce bundle size for front-end projects.