### PR TITLE
Use legacy version of Docker image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: npm
 
       - name: Start Keycloak
-        run: docker run --name keycloak -d -p 127.0.0.1:8080:8080 -e KEYCLOAK_USER=wwwy3y3 -e KEYCLOAK_PASSWORD=wwwy3y3 quay.io/keycloak/keycloak:latest
+        run: docker run --name keycloak -d -p 127.0.0.1:8080:8080 -e KEYCLOAK_USER=wwwy3y3 -e KEYCLOAK_PASSWORD=wwwy3y3 quay.io/keycloak/keycloak:legacy
 
       - name: Install test dependencies
         run: npm ci

--- a/test/authenticationManagement.spec.ts
+++ b/test/authenticationManagement.spec.ts
@@ -138,7 +138,7 @@ describe('Authentication management', () => {
     it('should fetch authenticator providers', async () => {
       const providers = await kcAdminClient.authenticationManagement.getAuthenticatorProviders();
       expect(providers).is.ok;
-      expect(providers.length).to.be.eq(36);
+      expect(providers.length).to.be.eq(38);
     });
   });
   describe('Flows', () => {

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -775,12 +775,11 @@ describe('Clients', () => {
         const user = await kcAdminClient.users.create({
           username,
         });
-        const accessToken = await kcAdminClient.clients.evaluateGenerateAccessToken(
-          {
-            id: clientUniqueId!,
-            userId: user.id,
-            scope: 'openid',
-          },
+        const accessToken = await kcAdminClient.clients.evaluateGenerateAccessToken({
+          id: clientUniqueId!,
+          userId: user.id,
+          scope: 'openid',
+        });
         const idToken = await kcAdminClient.clients.evaluateGenerateIdToken({
           id: clientUniqueId!,
           userId: user.id,


### PR DESCRIPTION
Changes the main workflow so the legacy (non-Quarkus) version of the Docker container is used. This allows the tests to pass again.