### PR TITLE
Add brief representation to types for RoleQuery

### DIFF
--- a/src/resources/roles.ts
+++ b/src/resources/roles.ts
@@ -7,6 +7,7 @@ export interface RoleQuery {
   first?: number;
   max?: number;
   search?: string;
+  briefRepresentation?: boolean;
 }
 
 export class Roles extends Resource<{realm?: string}> {


### PR DESCRIPTION
I noticed that briefRepresentation optin was missing from the type declaration for roles, so I added it