### PR TITLE
fix(make-request): fix type for find idp, clientPolicies and authenticationManagement

### DIFF
--- a/src/resources/authenticationManagement.ts
+++ b/src/resources/authenticationManagement.ts
@@ -109,7 +109,7 @@ export class AuthenticationManagement extends Resource {
     path: '/unregistered-required-actions',
   });
 
-  public getFlows = this.makeRequest<void, AuthenticationFlowRepresentation[]>({
+  public getFlows = this.makeRequest<{}, AuthenticationFlowRepresentation[]>({
     method: 'GET',
     path: '/flows',
   });

--- a/src/resources/clientPolicies.ts
+++ b/src/resources/clientPolicies.ts
@@ -39,7 +39,7 @@ export class ClientPolicies extends Resource<{realm?: string}> {
 
   /* Client Policies */
 
-  public listPolicies = this.makeRequest<void, ClientPoliciesRepresentation>({
+  public listPolicies = this.makeRequest<{}, ClientPoliciesRepresentation>({
     method: 'GET',
     path: '/policies',
   });

--- a/src/resources/identityProviders.ts
+++ b/src/resources/identityProviders.ts
@@ -11,7 +11,7 @@ export class IdentityProviders extends Resource<{realm?: string}> {
    * https://www.keycloak.org/docs-api/11.0/rest-api/#_identity_providers_resource
    */
 
-  public find = this.makeRequest<void, IdentityProviderRepresentation[]>({
+  public find = this.makeRequest<{}, IdentityProviderRepresentation[]>({
     method: 'GET',
     path: '/instances',
   });


### PR DESCRIPTION
Because of the void type I had to do this using the library (with typescript) :
`keycloakAdminClient.identityProviders.find({ realm } as void & { realm: string });`
I looked how other endpoints were called like find method for whoAmI and those endpoints use `{}` as PayloadType.