### PR TITLE
draft: refactor: PolicyRepresentation types for a better IDE support

### DIFF
--- a/src/defs/policyRepresentation.ts
+++ b/src/defs/policyRepresentation.ts
@@ -1,5 +1,5 @@
 /**
- * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_policyrepresentation
+ * https://www.keycloak.org/docs-api/18.0/rest-api/index.html#_policyrepresentation
  */
 
 export enum DecisionStrategy {
@@ -18,23 +18,55 @@ export enum Logic {
   NEGATIVE = 'NEGATIVE',
 }
 
-export interface PolicyRoleRepresentation {
-  id: string, 
-  required?: boolean
+export enum PolicyType {
+  GROUP = 'group',
+  ROLE = 'role',
 }
 
-export default interface PolicyRepresentation {
-  config?: Record<string, any>;
-  decisionStrategy?: DecisionStrategy;
-  description?: string;
-  id?: string;
-  logic?: Logic;
-  name?: string;
-  owner?: string;
-  policies?: string[];
-  resources?: string[];
-  scopes?: string[];
-  type?: string;
-  users?: string[];
-  roles?: PolicyRoleRepresentation[];
+export interface PolicyBaseRepresentation {
+  decisionStrategy: DecisionStrategy;
+  description: string;
+  id: string;
+  logic: Logic;
+  name: string;
+  type: PolicyType;
 }
+
+interface PolicyGroupRepresentationItem {
+  id: string;
+  path: string;
+}
+
+interface PolicyRoleRepresentationItem {
+  id: string;
+  required: boolean;
+}
+
+export type PolicyGroupRepresentation = PolicyBaseRepresentation & {
+  groups: PolicyGroupRepresentationItem[];
+  roles: never;
+}
+
+export type PolicyRoleRepresentation = PolicyBaseRepresentation & {
+  groups: never;
+  roles: PolicyRoleRepresentationItem[];
+}
+
+type DeepPartial<T> = T extends object ? {
+  [P in keyof T]?: DeepPartial<T[P]>;
+} : T;
+type DeepPartialWithOmit<T, R extends string> = T extends object ? {
+  [P in keyof Omit<T, R>]?: DeepPartial<T[P]>;
+} : T;
+
+type PolicyRepresentation = PolicyGroupRepresentation | PolicyRoleRepresentation;
+
+export type CreatePolicyRepresentationInput = DeepPartialWithOmit<CreatePolicyGroupRepresentationInput | CreatePolicyRoleRepresentationInput, "id">;
+export type CreatePolicyGroupRepresentationInput = DeepPartialWithOmit<PolicyGroupRepresentation, "id">;
+export type CreatePolicyRoleRepresentationInput = DeepPartialWithOmit<PolicyRoleRepresentation, "id">;
+
+export type UpdatePolicyRepresentationInput = DeepPartialWithOmit<CreatePolicyGroupRepresentationInput | CreatePolicyRoleRepresentationInput, "id"> & Pick<CreatePolicyGroupRepresentationInput | CreatePolicyRoleRepresentationInput, "id">;
+export type UpdatePolicyGroupRepresentationInput = DeepPartialWithOmit<PolicyGroupRepresentation, "id"> & Pick<PolicyGroupRepresentation, "id">;
+export type UpdatePolicyRoleRepresentationInput = DeepPartialWithOmit<PolicyRoleRepresentation, "id"> & Pick<PolicyRoleRepresentation, "id">;
+
+export default CreatePolicyRepresentationInput;


### PR DESCRIPTION
Hello, checked your admin client library and found in my mind a bug and a fix for it.

Hope this approach looks good for you, too.

PolicyRepresentation current policy types
- [x] group
- [x] role
- [ ] regexp
- [ ] client
- [ ] time
- [ ] user
- [ ] client scope
- [ ] aggregated

PermissionRepresentation
- [ ] Resource
- [ ] Scope

Cases for create/update/delete

PS: this works for me on 16 and i think for 17, 18 and 19-dev, too.

best regards