### PR TITLE
Drop Node.js version 12 from testing matrix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Node.js version 12 is no longer supported so let's drop it from out testing matrix.