### PR TITLE
Return ID from create client scope

### DIFF
--- a/src/resources/clientScopes.ts
+++ b/src/resources/clientScopes.ts
@@ -11,9 +11,10 @@ export class ClientScopes extends Resource<{realm?: string}> {
     path: '/client-scopes',
   });
 
-  public create = this.makeRequest<ClientScopeRepresentation, void>({
+  public create = this.makeRequest<ClientScopeRepresentation, {id: string}>({
     method: 'POST',
     path: '/client-scopes',
+    returnResourceIdInLocationHeader: {field: 'id'},
   });
 
   /**

--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -83,6 +83,27 @@ describe('Client Scopes', () => {
     expect(scope).to.be.ok;
     expect(scope.name).to.equal(currentClientScopeName);
   });
+  
+  it('create client scope and return id', async () => {
+    // ensure that the scope does not exist
+    try {
+      await kcAdminClient.clientScopes.delByName({
+        name: currentClientScopeName,
+      });
+    } catch (e) {
+      // ignore
+    }
+
+    const {id} = await kcAdminClient.clientScopes.create({
+      name: currentClientScopeName,
+    });
+
+    const scope = (await kcAdminClient.clientScopes.findOne({
+      id,
+    }))!;
+    expect(scope).to.be.ok;
+    expect(scope.name).to.equal(currentClientScopeName);
+  });
 
   it('find scope by id', async () => {
     const scope = await kcAdminClient.clientScopes.findOne({


### PR DESCRIPTION
Fixes #532 by returning the ID of the newly created client scope from the Location header