### PR TITLE
Fixes #543 - Re-enable skipped tests

### DIFF
--- a/test/clientScopes.spec.ts
+++ b/test/clientScopes.spec.ts
@@ -83,7 +83,7 @@ describe('Client Scopes', () => {
     expect(scope).to.be.ok;
     expect(scope.name).to.equal(currentClientScopeName);
   });
-  
+
   it('create client scope and return id', async () => {
     // ensure that the scope does not exist
     try {
@@ -135,7 +135,7 @@ describe('Client Scopes', () => {
     expect(scope).to.be.undefined;
   });
 
-  it.skip('update client scope', async () => {
+  it('update client scope', async () => {
     const {id, description: oldDescription} = currentClientScope;
     const description = 'This scope is totally awesome.';
 

--- a/test/clients.spec.ts
+++ b/test/clients.spec.ts
@@ -1287,7 +1287,7 @@ describe('Clients', () => {
       expect(result).to.be.ok;
     });
 
-    it.skip('Enable fine grained permissions', async () => {
+    it('Enable fine grained permissions', async () => {
       const permission = await kcAdminClient.clients.updateFineGrainPermission(
         {id: currentClient.id!},
         {enabled: true},
@@ -1297,7 +1297,7 @@ describe('Clients', () => {
       });
     });
 
-    it.skip('List fine grained permissions for this client', async () => {
+    it('List fine grained permissions for this client', async () => {
       const permissions = (await kcAdminClient.clients.listFineGrainPermissions(
         {id: currentClient.id!},
       ))!;

--- a/test/groupUser.spec.ts
+++ b/test/groupUser.spec.ts
@@ -92,7 +92,7 @@ describe('Group user integration', () => {
   /**
    * Authorization permissions
    */
-  describe.skip('authorization permissions', () => {
+  describe('authorization permissions', () => {
     before(async () => {
       const clients = await kcAdminClient.clients.find();
       managementClient = clients.find(client => client.clientId === 'master-realm')!;

--- a/test/idp.spec.ts
+++ b/test/idp.spec.ts
@@ -164,7 +164,7 @@ describe('Identity providers', () => {
     );
   });
 
-  it.skip('Enable fine grained permissions', async () => {
+  it('Enable fine grained permissions', async () => {
     const permission = await kcAdminClient.identityProviders.updatePermission(
       {alias: currentIdpAlias},
       {enabled: true},
@@ -174,7 +174,7 @@ describe('Identity providers', () => {
     });
   });
 
-  it.skip('list permissions', async () => {
+  it('list permissions', async () => {
     const permissions = await kcAdminClient.identityProviders.listPermissions({
       alias: currentIdpAlias,
     });

--- a/test/realms.spec.ts
+++ b/test/realms.spec.ts
@@ -324,7 +324,7 @@ describe('Realms', () => {
       expect(managementPermissions).to.be.ok;
     });
 
-    it.skip('enable users management permissions', async () => {
+    it('enable users management permissions', async () => {
       const managementPermissions =
         await kcAdminClient.realms.updateUsersManagementPermissions({
           realm: currentRealmName,
@@ -442,21 +442,21 @@ describe('Realms', () => {
   describe('Realm localization', () => {
     currentRealmName = 'master';
 
-    it.skip('enable localization', async () => {
+    it('enable localization', async () => {
       await kcAdminClient.realms.getRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: 'nl',
       });
     });
 
-    it.skip('should add localization', async () => {
+    it('should add localization', async () => {
       await kcAdminClient.realms.addLocalization(
         {realm: currentRealmName, selectedLocale: 'nl', key: 'theKey'},
         'value',
       );
     });
 
-    it.skip('should get realm specific locales', async () => {
+    it('should get realm specific locales', async () => {
       const locales = await kcAdminClient.realms.getRealmSpecificLocales({
         realm: currentRealmName,
       });
@@ -465,7 +465,7 @@ describe('Realms', () => {
       expect(locales).to.be.deep.eq(['nl']);
     });
 
-    it.skip('should get localization for specified locale', async () => {
+    it('should get localization for specified locale', async () => {
       const texts = await kcAdminClient.realms.getRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: 'nl',
@@ -475,7 +475,7 @@ describe('Realms', () => {
       expect(texts.theKey).to.be.eq('value');
     });
 
-    it.skip('should delete localization for specified locale key', async () => {
+    it('should delete localization for specified locale key', async () => {
       await kcAdminClient.realms.deleteRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: 'nl',
@@ -490,7 +490,7 @@ describe('Realms', () => {
       expect(texts).to.be.deep.eq({});
     });
 
-    it.skip('should delete localization for specified locale', async () => {
+    it('should delete localization for specified locale', async () => {
       await kcAdminClient.realms.deleteRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: 'nl',

--- a/test/roles.spec.ts
+++ b/test/roles.spec.ts
@@ -104,7 +104,7 @@ describe('Roles', () => {
     expect(users).to.be.an('array');
   });
 
-  it.skip('Enable fine grained permissions', async () => {
+  it('Enable fine grained permissions', async () => {
     const permission = await client.roles.updatePermission(
       {id: currentRole.id!},
       {enabled: true},
@@ -114,7 +114,7 @@ describe('Roles', () => {
     });
   });
 
-  it.skip('List fine grained permissions for this role', async () => {
+  it('List fine grained permissions for this role', async () => {
     const permissions = (await client.roles.listPermissions({
       id: currentRole.id!,
     }))!;

--- a/test/users.spec.ts
+++ b/test/users.spec.ts
@@ -86,17 +86,17 @@ describe('Users', function () {
     expect(numUsers).to.equal(1);
   });
 
-  it.skip('gets the profile', async () => {
+  it('gets the profile', async () => {
     const profile = await kcAdminClient.users.getProfile();
     expect(profile).to.be.ok;
   });
 
-  it.skip('updates the profile', async () => {
+  it('updates the profile', async () => {
     const profile = await kcAdminClient.users.updateProfile({});
     expect(profile).to.be.ok;
   });
 
-  it.skip('find users by custom attributes', async () => {
+  it('find users by custom attributes', async () => {
     // Searching by attributes is only available from Keycloak > 15
     const users = await kcAdminClient.users.find({key: 'value'});
     expect(users.length).to.be.equal(2);


### PR DESCRIPTION
As per requirement in issue  #543, removed all `.skip()` entries in the [test](test) files.
(Also a little trailing-whitespaces removal @ L86 of [test/clientScopes.spec.ts](test/clientScopes.spec.ts) got caught in the process, hope you won't mind)