### PR TITLE
Adds endpoint for finding a group by its path

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/
 - Update client policies policies (`PUT /{realm}/client-policies/policies`)
 - Get client policies profiles (`GET /{realm}/client-policies/profiles`)
 - Update client policies profiles (`PUT /{realm}/client-policies/profiles`)
-
+- Get a group by path (`GET /{realm}/group-by-path/{path}`)
 ### [Role](https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_roles_resource)
 
 Demo code: https://github.com/keycloak/keycloak-nodejs-admin-client/blob/master/test/roles.spec.ts

--- a/src/resources/realms.ts
+++ b/src/resources/realms.ts
@@ -106,6 +106,15 @@ export class Realms extends Resource {
     urlParamKeys: ['realm', 'id'],
   });
 
+  public getGroupByPath = this.makeRequest<
+    { path: string, realm: string }, 
+    GroupRepresentation
+  >({
+    method: 'GET',
+    path: '/{realm}/group-by-path/{path}',
+    urlParamKeys: ['realm', 'path']
+  });
+
   /**
    * Get events Returns all events, or filters them based on URL query parameters listed here
    */

--- a/test/realms.spec.ts
+++ b/test/realms.spec.ts
@@ -220,6 +220,16 @@ describe('Realms', () => {
       expect(defaultGroups[0].id).to.be.eq(currentGroup.id);
     });
 
+    it('get a group by its path name', async () => {
+      const queriedGroup = await kcAdminClient.realms.getGroupByPath({
+        realm: currentRealmName,
+        path: groupName,
+      })
+
+      expect(queriedGroup).to.be.ok;
+      expect(queriedGroup.id).to.be.eq(currentGroup.id);
+    });
+
     it('remove group from default groups', async () => {
       await kcAdminClient.realms.removeDefaultGroup({
         id: currentGroup.id!,


### PR DESCRIPTION
This patch adds client support for the `GET admin/realms/{realm}/group-by-path/{path}` endpoint ([ref](https://www.keycloak.org/docs-api/18.0/rest-api/#_getgroupbypath)).

Closes #549